### PR TITLE
A few little changes improve attiny85/digispark support

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -114,7 +114,7 @@ void Adafruit_NeoPixel::show(void) {
 // AVR ATtiny85 chips, like the MCU on the Digispark, do not support
 // 'mul' instructions, so we use regular nops instead
 #ifdef __AVR_ATtiny85__
-  #define NOP2 "rjmp .+0"	// used two clock cycles, but requires only one instruction
+  #define NOP2 "rjmp .+0\n\t"	// used two clock cycles, but requires only one instruction
   				// keeps relative branches from breaking
 #else
   #define NOP2 "mul  r0, r0\n\t"             


### PR DESCRIPTION
I've committed a couple of tweaks which allow Adafruit_NeoPixel to work better with attiny85's running tinycore/digispark sketches.

The next version of the Digispark Arduino app will let users choose from clock speeds of 16, 8, and 1mhz to improve compatibility with existing arduino libraries and provide more energy efficiency for battery powered projects. I haven't gotten 8mhz to work yet because of a weird error, but 16.0mhz seems to work great with my 400mhz florapixels and a digispark.

This may also be a bit relevent to the Flora Gemma? ^_^
