### PR TITLE
Making Color utility function static

### DIFF
--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -48,8 +48,9 @@ class Adafruit_NeoPixel {
     setBrightness(uint8_t);
   uint16_t
     numPixels(void);
+  static uint32_t
+    Color(uint8_t r, uint8_t g, uint8_t b);
   uint32_t
-    Color(uint8_t r, uint8_t g, uint8_t b),
     getPixelColor(uint16_t n);
 
  private:


### PR DESCRIPTION
The `Color` function does not refer to or alter any instance members, so it can (and should) be `static`.
