### PR TITLE
Make "get" methods const

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -867,7 +867,7 @@ uint32_t Adafruit_NeoPixel::Color(uint8_t r, uint8_t g, uint8_t b) {
 }
 
 // Query color from previously-set pixel (returns packed 32-bit RGB value)
-uint32_t Adafruit_NeoPixel::getPixelColor(uint16_t n) {
+uint32_t Adafruit_NeoPixel::getPixelColor(uint16_t n) const {
 
   if(n < numLEDs) {
     uint16_t ofs = n * 3;

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -52,7 +52,7 @@ class Adafruit_NeoPixel {
   static uint32_t
     Color(uint8_t r, uint8_t g, uint8_t b);
   uint32_t
-    getPixelColor(uint16_t n);
+    getPixelColor(uint16_t n) const;
 
  private:
 


### PR DESCRIPTION
This function does not alter state, so it should be `const`.
