### PR TITLE
Color Wheel Fix

### DIFF
--- a/examples/strandtest/strandtest.ino
+++ b/examples/strandtest/strandtest.ino
@@ -109,14 +109,15 @@ void theaterChaseRainbow(uint8_t wait) {
 // Input a value 0 to 255 to get a color value.
 // The colours are a transition r - g - b - back to r.
 uint32_t Wheel(byte WheelPos) {
+  WheelPos = 255 - WheelPos;
   if(WheelPos < 85) {
-   return strip.Color(WheelPos * 3, 255 - WheelPos * 3, 0);
-  } else if(WheelPos < 170) {
-   WheelPos -= 85;
    return strip.Color(255 - WheelPos * 3, 0, WheelPos * 3);
+  } else if(WheelPos < 170) {
+    WheelPos -= 85;
+   return strip.Color(0, WheelPos * 3, 255 - WheelPos * 3);
   } else {
    WheelPos -= 170;
-   return strip.Color(0, WheelPos * 3, 255 - WheelPos * 3);
+   return strip.Color(WheelPos * 3, 255 - WheelPos * 3, 0);
   }
 }
 


### PR DESCRIPTION
The supposed R-G-B spectrum of the Wheel method was all wrong. It started with a green, then went to yellow, then red, then purple, then blue. I've completely fixed this, and tested it on my neopixel strands. This new Wheel method starts at pure red, moves to orange, yellow, green, and the full rainbow, as it is in nature.
