### PR TITLE
Adding independent values for R, G and B brightness.

### DIFF
--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -56,6 +56,7 @@ class Adafruit_NeoPixel {
     setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b),
     setPixelColor(uint16_t n, uint32_t c),
     setBrightness(uint8_t),
+    setBrightness(uint8_t r, uint8_t g, uint8_t b),
     clear();
   uint8_t
    *getPixels(void) const,
@@ -76,7 +77,9 @@ class Adafruit_NeoPixel {
     numBytes;      // Size of 'pixels' buffer below
   uint8_t
     pin,           // Output pin number
-    brightness,
+    brightnessR,
+    brightnessG,
+    brightnessB,
    *pixels,        // Holds LED color values (3 bytes each)
     rOffset,       // Index of red byte within each 3-byte pixel
     gOffset,       // Index of green byte


### PR DESCRIPTION
When doing a project that uses 3V batteries I noticed that the blue gets very weak when voltage drops. Having independent values of brightness for R, G and B and making them different (in my case 20, 32 and 128) solved the problem.

This is backwards compatible as it still has the setBrightness method that takes one parameter. The only problem I solved in a non ideal way was the getBrightness method.
