### PR TITLE
add HSV -> Color converter

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1082,6 +1082,39 @@ uint32_t Adafruit_NeoPixel::Color(uint8_t r, uint8_t g, uint8_t b) {
   return ((uint32_t)r << 16) | ((uint32_t)g <<  8) | b;
 }
 
+// Convert Hue/Saturation/Brightness values to a packed 32-bit RBG color.
+// hue must be a float value between 0 and 360
+// saturation must be a float value between 0 and 1
+// brightness must be a float value between 0 and 1
+uint32_t Adafruit_NeoPixel::HSVColor(float h, float s, float v) {
+  int i, b, p, q, t;
+  float f;
+
+  h /= 60.0;  // sector 0 to 5
+  i = floor( h );
+  f = h - i;  // factorial part of h
+
+  b = v * 255;
+  p = v * ( 1 - s ) * 255;
+  q = v * ( 1 - s * f ) * 255;
+  t = v * ( 1 - s * ( 1 - f ) ) * 255;
+
+  switch( i ) {
+    case 0:
+      return Color(b, t, p);
+    case 1:
+      return Color(q, b, p);
+    case 2:
+      return Color(p, b, t);
+    case 3:
+      return Color(p, q, b);
+    case 4:
+      return Color(t, p, b);
+    default:
+      return Color(b, p, q);
+  }
+}
+
 // Query color from previously-set pixel (returns packed 32-bit RGB value)
 uint32_t Adafruit_NeoPixel::getPixelColor(uint16_t n) const {
   if(n >= numLEDs) {

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1087,6 +1087,10 @@ uint32_t Adafruit_NeoPixel::Color(uint8_t r, uint8_t g, uint8_t b) {
 // saturation must be a float value between 0 and 1
 // brightness must be a float value between 0 and 1
 uint32_t Adafruit_NeoPixel::HSVColor(float h, float s, float v) {
+  h = constrain(h, 0, 360);
+  s = constrain(s, 0, 1);
+  v = constrain(v, 0, 1);
+
   int i, b, p, q, t;
   float f;
 

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -68,6 +68,8 @@ class Adafruit_NeoPixel {
     numPixels(void) const;
   static uint32_t
     Color(uint8_t r, uint8_t g, uint8_t b);
+  static uint32_t
+    HSVColor(float h, float s, float v);
   uint32_t
     getPixelColor(uint16_t n) const;
   inline bool


### PR DESCRIPTION
Add a static method to convert hue/saturation/brightness values to a 32-bit packed color value. This allows for extremely simple color cycling. Controlling brightness is also straightforward and can be applied to individual pixels rather than full strands.

The algorithm was adapted from here: http://www.cs.rit.edu/~ncs/color/t%5Fconvert.html
