### PR TITLE
Rearranged code sequence to more closely match WS2812B spec on T0H and T...

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -162,72 +162,72 @@ void Adafruit_NeoPixel::show(void) {
        "headD:"                   "\n\t" // Clk  Pseudocode
         // Bit 7:
         "out  %[port] , %[hi]"    "\n\t" // 1    PORT = hi
-        "mov  %[n2]   , %[lo]"    "\n\t" // 1    n2   = lo
+        "rjmp .+0"                "\n\t" // 2    nop nop  
         "out  %[port] , %[n1]"    "\n\t" // 1    PORT = n1
-        "rjmp .+0"                "\n\t" // 2    nop nop
+        "mov  %[n2]   , %[lo]"    "\n\t" // 1    n2   = lo
         "sbrc %[byte] , 6"        "\n\t" // 1-2  if(b & 0x40)
          "mov %[n2]   , %[hi]"    "\n\t" // 0-1   n2 = hi
         "out  %[port] , %[lo]"    "\n\t" // 1    PORT = lo
         "rjmp .+0"                "\n\t" // 2    nop nop
         // Bit 6:
         "out  %[port] , %[hi]"    "\n\t" // 1    PORT = hi
-        "mov  %[n1]   , %[lo]"    "\n\t" // 1    n1   = lo
-        "out  %[port] , %[n2]"    "\n\t" // 1    PORT = n2
         "rjmp .+0"                "\n\t" // 2    nop nop
+        "out  %[port] , %[n2]"    "\n\t" // 1    PORT = n2
+        "mov  %[n1]   , %[lo]"    "\n\t" // 1    n1   = lo
         "sbrc %[byte] , 5"        "\n\t" // 1-2  if(b & 0x20)
          "mov %[n1]   , %[hi]"    "\n\t" // 0-1   n1 = hi
         "out  %[port] , %[lo]"    "\n\t" // 1    PORT = lo
         "rjmp .+0"                "\n\t" // 2    nop nop
         // Bit 5:
         "out  %[port] , %[hi]"    "\n\t" // 1    PORT = hi
-        "mov  %[n2]   , %[lo]"    "\n\t" // 1    n2   = lo
-        "out  %[port] , %[n1]"    "\n\t" // 1    PORT = n1
         "rjmp .+0"                "\n\t" // 2    nop nop
+        "out  %[port] , %[n1]"    "\n\t" // 1    PORT = n1
+        "mov  %[n2]   , %[lo]"    "\n\t" // 1    n2   = lo
         "sbrc %[byte] , 4"        "\n\t" // 1-2  if(b & 0x10)
          "mov %[n2]   , %[hi]"    "\n\t" // 0-1   n2 = hi
         "out  %[port] , %[lo]"    "\n\t" // 1    PORT = lo
         "rjmp .+0"                "\n\t" // 2    nop nop
         // Bit 4:
         "out  %[port] , %[hi]"    "\n\t" // 1    PORT = hi
-        "mov  %[n1]   , %[lo]"    "\n\t" // 1    n1   = lo
-        "out  %[port] , %[n2]"    "\n\t" // 1    PORT = n2
         "rjmp .+0"                "\n\t" // 2    nop nop
+        "out  %[port] , %[n2]"    "\n\t" // 1    PORT = n2
+        "mov  %[n1]   , %[lo]"    "\n\t" // 1    n1   = lo
         "sbrc %[byte] , 3"        "\n\t" // 1-2  if(b & 0x08)
          "mov %[n1]   , %[hi]"    "\n\t" // 0-1   n1 = hi
         "out  %[port] , %[lo]"    "\n\t" // 1    PORT = lo
         "rjmp .+0"                "\n\t" // 2    nop nop
         // Bit 3:
         "out  %[port] , %[hi]"    "\n\t" // 1    PORT = hi
-        "mov  %[n2]   , %[lo]"    "\n\t" // 1    n2   = lo
-        "out  %[port] , %[n1]"    "\n\t" // 1    PORT = n1
         "rjmp .+0"                "\n\t" // 2    nop nop
+        "out  %[port] , %[n1]"    "\n\t" // 1    PORT = n1
+        "mov  %[n2]   , %[lo]"    "\n\t" // 1    n2   = lo
         "sbrc %[byte] , 2"        "\n\t" // 1-2  if(b & 0x04)
          "mov %[n2]   , %[hi]"    "\n\t" // 0-1   n2 = hi
         "out  %[port] , %[lo]"    "\n\t" // 1    PORT = lo
         "rjmp .+0"                "\n\t" // 2    nop nop
         // Bit 2:
         "out  %[port] , %[hi]"    "\n\t" // 1    PORT = hi
-        "mov  %[n1]   , %[lo]"    "\n\t" // 1    n1   = lo
-        "out  %[port] , %[n2]"    "\n\t" // 1    PORT = n2
         "rjmp .+0"                "\n\t" // 2    nop nop
+        "out  %[port] , %[n2]"    "\n\t" // 1    PORT = n2
+        "mov  %[n1]   , %[lo]"    "\n\t" // 1    n1   = lo
         "sbrc %[byte] , 1"        "\n\t" // 1-2  if(b & 0x02)
          "mov %[n1]   , %[hi]"    "\n\t" // 0-1   n1 = hi
         "out  %[port] , %[lo]"    "\n\t" // 1    PORT = lo
         "rjmp .+0"                "\n\t" // 2    nop nop
         // Bit 1:
         "out  %[port] , %[hi]"    "\n\t" // 1    PORT = hi
-        "mov  %[n2]   , %[lo]"    "\n\t" // 1    n2   = lo
-        "out  %[port] , %[n1]"    "\n\t" // 1    PORT = n1
         "rjmp .+0"                "\n\t" // 2    nop nop
+        "out  %[port] , %[n1]"    "\n\t" // 1    PORT = n1
+        "mov  %[n2]   , %[lo]"    "\n\t" // 1    n2   = lo
         "sbrc %[byte] , 0"        "\n\t" // 1-2  if(b & 0x01)
          "mov %[n2]   , %[hi]"    "\n\t" // 0-1   n2 = hi
         "out  %[port] , %[lo]"    "\n\t" // 1    PORT = lo
         "sbiw %[count], 1"        "\n\t" // 2    i-- (don't act on Z flag yet)
         // Bit 0:
         "out  %[port] , %[hi]"    "\n\t" // 1    PORT = hi
-        "mov  %[n1]   , %[lo]"    "\n\t" // 1    n1   = lo
-        "out  %[port] , %[n2]"    "\n\t" // 1    PORT = n2
         "ld   %[byte] , %a[ptr]+" "\n\t" // 2    b = *ptr++
+        "out  %[port] , %[n2]"    "\n\t" // 1    PORT = n2
+        "mov  %[n1]   , %[lo]"    "\n\t" // 1    n1   = lo
         "sbrc %[byte] , 7"        "\n\t" // 1-2  if(b & 0x80)
          "mov %[n1]   , %[hi]"    "\n\t" // 0-1   n1 = hi
         "out  %[port] , %[lo]"    "\n\t" // 1    PORT = lo


### PR DESCRIPTION
...0L timing.

Previous version had T0H very short, this extends the timing by one clock cycle but maintains overall code length.
