### PR TITLE
Support for nRF51822 based boards

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -56,7 +56,7 @@ Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, uint8_t t) : numLEDs
     gOffset = 1;
     bOffset = 2;
   }
-  
+
 }
 
 Adafruit_NeoPixel::~Adafruit_NeoPixel() {

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -823,6 +823,77 @@ void Adafruit_NeoPixel::show(void) {
 #error "Sorry, only 48 MHz is supported, please set Tools > CPU Speed to 48 MHz"
 #endif
 
+#elif defined(NRF51) || defined(__RFduino__)
+
+#ifdef NRF51
+  int nRF51pin = Pin_nRF51822_to_Arduino(pin);
+#else
+  int nRF51pin = pin;
+#endif
+  uint8_t *p = pixels, *end = p + numBytes;
+
+  // based off of: http://forum.rfduino.com/index.php?topic=787.0
+  noInterrupts();
+  while(p < end) {
+    uint8_t pix = *p++;
+
+    if((type & NEO_SPDMASK) == NEO_KHZ800) { // 800 KHz bitstream
+      for(int i = 7; i >= 0; i--) {
+        NRF_GPIO->OUTSET = (1UL << nRF51pin);
+
+        if(pix & (0x01 << i)) {
+          __ASM ( \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                );
+          NRF_GPIO->OUTCLR = (1UL << nRF51pin);
+
+        } else {
+          NRF_GPIO->OUTCLR = (1UL << nRF51pin);
+          __ASM ( \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                );
+        }
+      }
+    } else { // 400 KHz bitstream
+      for(int i = 7; i >= 0; i--) {
+        NRF_GPIO->OUTSET = (1UL << nRF51pin);
+
+        if(pix & (0x01 << i)) {
+          __ASM ( \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                );
+          NRF_GPIO->OUTCLR = (1UL << nRF51pin);
+        } else {
+          NRF_GPIO->OUTCLR = (1UL << nRF51pin);
+          __ASM ( \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                " NOP\n\t" \
+                );
+        }
+      }
+    }
+  }
+  delayMicroseconds(50); // latch and reset WS2812.
+  interrupts();
 
 #else // Arduino Due
 


### PR DESCRIPTION
Add support for the following [Nordic Semiconductor nRF51822](https://www.nordicsemi.com/eng/Products/Bluetooth-Smart-Bluetooth-low-energy/nRF51822) based boards:
 * [RedBearLab](https://www.nordicsemi.com/eng/Products/Bluetooth-Smart-Bluetooth-low-energy/nRF51822)
  * [BLE Nano](http://redbearlab.com/blenano/)
  * [nRF51822](http://redbearlab.com/redbearlab-nrf51822/)
 * [RFduino](http://www.rfduino.com)

Base on tolson's RFduino forum post:  http://forum.rfduino.com/index.php?topic=787.0

Tested with [NeoPixel Ring - 16](https://www.adafruit.com/products/1463) at NEO_KHZ800 and NEO_KHZ400, on RBL nRF51822 and RFduino.