### PR TITLE
Added library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=Adafruit NeoPixel
+version=1.0
+author=Adafruit
+maintainer=Adafruit <info@adafruit.com>
+sentence=Arduino library for controlling single-wire-based LED pixels and strip.
+paragraph=Arduino library for controlling single-wire-based LED pixels and strip.
+category=Display
+url=https://github.com/adafruit/Adafruit_NeoPixel
+architectures=*


### PR DESCRIPTION
This PR adds library.properties, a metadata file used by the upcoming library manager to list libraries under the appropriate category and provide the user some useful additional information

See https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification for additional info on the format and the optional folder structure