### PR TITLE
Fix harmless compiler warnings

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -33,8 +33,9 @@
 
 #include "Adafruit_NeoPixel.h"
 
-Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, uint8_t t) : numLEDs(n), numBytes(n * 3), pin(p), pixels(NULL)
-  ,type(t), brightness(0), endTime(0)
+Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, uint8_t t) :
+   numLEDs(n), numBytes(n * 3), pin(p), brightness(0),
+   pixels(NULL), type(t), endTime(0)
 #ifdef __AVR__
   ,port(portOutputRegister(digitalPinToPort(p))),
    pinMask(digitalPinToBitMask(p))


### PR DESCRIPTION
These compiler warnings are harmless, except for the psychological effect they have on customers when something else about their project doesn't work.