### PR TITLE
setBrightness(0) error

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1187,6 +1187,7 @@ void Adafruit_NeoPixel::setBrightness(uint8_t b) {
       *ptr++ = (c * scale) >> 8;
     }
     brightness = newBrightness;
+    // brightness = newBrightness == 1 ? 0 : newBrightness;
   }
 }
 

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1186,8 +1186,7 @@ void Adafruit_NeoPixel::setBrightness(uint8_t b) {
       c      = *ptr;
       *ptr++ = (c * scale) >> 8;
     }
-    brightness = newBrightness;
-    // brightness = newBrightness == 1 ? 0 : newBrightness;
+    brightness = newBrightness == 1 ? 0 : newBrightness;
   }
 }
 


### PR DESCRIPTION
I'm seeing what I believe to be a bug in setting brightness. The following sketch illustrates what I'm seeing - [gist](https://gist.github.com/440aeec8a6fe38d8e69f.git)

    // example sketch to demonstrate percieved neopixel library error.
    // expect green > off(-ish) > blue > off > red > off > green > off(-ish) > blue > off > red
    // get    green > off(-ish) > blue > off > red > off > off   > off       > blue > off > red


    #include <Adafruit_NeoPixel.h>

    #define PIN 0
    Adafruit_NeoPixel strip = Adafruit_NeoPixel(1, PIN, NEO_RGB + NEO_KHZ800);

    void setup() {
      pinMode(PIN, OUTPUT);
      strip.begin();
      strip.setPixelColor(0, strip.Color(255,0,0));
      strip.show();
    }

    void loop() {
      uint16_t wait = 2000;
      strip.setPixelColor(0, strip.Color(0,255,0)); // green
      strip.setBrightness(255);
      strip.show();
      delay(wait);
      // setting brightness to 1 is OK but pixel not 100% off
      strip.setBrightness(1);
      strip.show();
      delay(wait);

      strip.setPixelColor(0, strip.Color(0,0,255)); // blue
      strip.setBrightness(255);
      strip.show();
      delay(wait);
      // setting color to 'black' is ok...
      strip.setPixelColor(0, strip.Color(0,0,0));
      strip.show();
      delay(wait);

      strip.setPixelColor(0, strip.Color(255,0,0)); // red
      strip.setBrightness(255);
      strip.show();
      delay(wait);
      // but setting brightness to 0 kills strip
      strip.setBrightness(0);
      strip.show();
      delay(wait);
      // and we never get back brightness until we set pixel color
    }

A simple ternary in Adafruit_NeoPixel::setBrightness(uint8_t b) seems to fix the issue, but I'm not aware of other edge cases that it may affect.