### PR TITLE
expose the pin the Adafruit_NeoPixel is driving. (pin cannot be changed)

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -35,7 +35,7 @@
 #include "Adafruit_NeoPixel.h"
 
 // Constructor when length, pin and type are known at compile-time:
-Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, neoPixelType t) :
+Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, int8_t p, neoPixelType t) :
   brightness(0), pixels(NULL), endTime(0), begun(false)
 {
   updateType(t);
@@ -1109,7 +1109,7 @@ void Adafruit_NeoPixel::show(void) {
 }
 
 // Set the output pin number
-void Adafruit_NeoPixel::setPin(uint8_t p) {
+void Adafruit_NeoPixel::setPin(int8_t p) {
   if(begun && (pin >= 0)) pinMode(pin, INPUT);
   if(p >= 0) {
     pin = p;
@@ -1124,7 +1124,7 @@ void Adafruit_NeoPixel::setPin(uint8_t p) {
   }
 }
 
-uint8_t Adafruit_NeoPixel::getPin() const {
+int8_t Adafruit_NeoPixel::getPin() const {
   return pin;
 }
 

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1124,6 +1124,10 @@ void Adafruit_NeoPixel::setPin(uint8_t p) {
   }
 }
 
+uint8_t Adafruit_NeoPixel::getPin() const {
+  return pin;
+}
+
 // Set pixel color from separate R,G,B components:
 void Adafruit_NeoPixel::setPixelColor(
  uint16_t n, uint8_t r, uint8_t g, uint8_t b) {

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -135,6 +135,7 @@ class Adafruit_NeoPixel {
     updateType(neoPixelType t);
   uint8_t
    *getPixels(void) const,
+    getPin(void) const,
     getBrightness(void) const;
   uint16_t
     numPixels(void) const;

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -118,14 +118,14 @@ class Adafruit_NeoPixel {
  public:
 
   // Constructor: number of LEDs, pin number, LED type
-  Adafruit_NeoPixel(uint16_t n, uint8_t p=6, neoPixelType t=NEO_GRB + NEO_KHZ800);
+  Adafruit_NeoPixel(uint16_t n, int8_t p=6, neoPixelType t=NEO_GRB + NEO_KHZ800);
   Adafruit_NeoPixel(void);
   ~Adafruit_NeoPixel();
 
   void
     begin(void),
     show(void),
-    setPin(uint8_t p),
+    setPin(int8_t p),
     setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b),
     setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t w),
     setPixelColor(uint16_t n, uint32_t c),
@@ -135,8 +135,9 @@ class Adafruit_NeoPixel {
     updateType(neoPixelType t);
   uint8_t
    *getPixels(void) const,
-    getPin(void) const,
     getBrightness(void) const;
+  int8_t
+    getPin(void) const;
   uint16_t
     numPixels(void) const;
   static uint32_t


### PR DESCRIPTION
I needed this because I am passing the Adafruit_NeoPixel structure to functions that use the pin as an index into an array.
