### PR TITLE
Create a typedef neoPixelColor to allow type clarity.

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1171,7 +1171,7 @@ void Adafruit_NeoPixel::setPixelColor(
 }
 
 // Set pixel color from 'packed' 32-bit RGB color:
-void Adafruit_NeoPixel::setPixelColor(uint16_t n, uint32_t c) {
+void Adafruit_NeoPixel::setPixelColor(uint16_t n, neoPixelColor c) {
   if(n < numLEDs) {
     uint8_t *p,
       r = (uint8_t)(c >> 16),
@@ -1197,18 +1197,18 @@ void Adafruit_NeoPixel::setPixelColor(uint16_t n, uint32_t c) {
 
 // Convert separate R,G,B into packed 32-bit RGB color.
 // Packed format is always RGB, regardless of LED strand color order.
-uint32_t Adafruit_NeoPixel::Color(uint8_t r, uint8_t g, uint8_t b) {
-  return ((uint32_t)r << 16) | ((uint32_t)g <<  8) | b;
+neoPixelColor Adafruit_NeoPixel::Color(uint8_t r, uint8_t g, uint8_t b) {
+  return ((neoPixelColor)r << 16) | ((neoPixelColor)g <<  8) | b;
 }
 
 // Convert separate R,G,B,W into packed 32-bit WRGB color.
 // Packed format is always WRGB, regardless of LED strand color order.
-uint32_t Adafruit_NeoPixel::Color(uint8_t r, uint8_t g, uint8_t b, uint8_t w) {
-  return ((uint32_t)w << 24) | ((uint32_t)r << 16) | ((uint32_t)g <<  8) | b;
+neoPixelColor Adafruit_NeoPixel::Color(uint8_t r, uint8_t g, uint8_t b, uint8_t w) {
+  return ((neoPixelColor)w << 24) | ((neoPixelColor)r << 16) | ((neoPixelColor)g <<  8) | b;
 }
 
 // Query color from previously-set pixel (returns packed 32-bit RGB value)
-uint32_t Adafruit_NeoPixel::getPixelColor(uint16_t n) const {
+neoPixelColor Adafruit_NeoPixel::getPixelColor(uint16_t n) const {
   if(n >= numLEDs) return 0; // Out of bounds, return no color.
 
   uint8_t *p;
@@ -1221,27 +1221,27 @@ uint32_t Adafruit_NeoPixel::getPixelColor(uint16_t n) const {
       // value used when setting the pixel color, but there will always be
       // some error -- those bits are simply gone.  Issue is most
       // pronounced at low brightness levels.
-      return (((uint32_t)(p[rOffset] << 8) / brightness) << 16) |
-             (((uint32_t)(p[gOffset] << 8) / brightness) <<  8) |
-             ( (uint32_t)(p[bOffset] << 8) / brightness       );
+      return (((neoPixelColor)(p[rOffset] << 8) / brightness) << 16) |
+             (((neoPixelColor)(p[gOffset] << 8) / brightness) <<  8) |
+             ( (neoPixelColor)(p[bOffset] << 8) / brightness       );
     } else {
       // No brightness adjustment has been made -- return 'raw' color
-      return ((uint32_t)p[rOffset] << 16) |
-             ((uint32_t)p[gOffset] <<  8) |
-              (uint32_t)p[bOffset];
+      return ((neoPixelColor)p[rOffset] << 16) |
+             ((neoPixelColor)p[gOffset] <<  8) |
+              (neoPixelColor)p[bOffset];
     }
   } else {                 // Is RGBW-type device
     p = &pixels[n * 4];
     if(brightness) { // Return scaled color
-      return (((uint32_t)(p[wOffset] << 8) / brightness) << 24) |
-             (((uint32_t)(p[rOffset] << 8) / brightness) << 16) |
-             (((uint32_t)(p[gOffset] << 8) / brightness) <<  8) |
-             ( (uint32_t)(p[bOffset] << 8) / brightness       );
+      return (((neoPixelColor)(p[wOffset] << 8) / brightness) << 24) |
+             (((neoPixelColor)(p[rOffset] << 8) / brightness) << 16) |
+             (((neoPixelColor)(p[gOffset] << 8) / brightness) <<  8) |
+             ( (neoPixelColor)(p[bOffset] << 8) / brightness       );
     } else { // Return raw color
-      return ((uint32_t)p[wOffset] << 24) |
-             ((uint32_t)p[rOffset] << 16) |
-             ((uint32_t)p[gOffset] <<  8) |
-              (uint32_t)p[bOffset];
+      return ((neoPixelColor)p[wOffset] << 24) |
+             ((neoPixelColor)p[rOffset] << 16) |
+             ((neoPixelColor)p[gOffset] <<  8) |
+              (neoPixelColor)p[bOffset];
     }
   }
 }

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -113,6 +113,8 @@ typedef uint8_t  neoPixelType;
 typedef uint16_t neoPixelType;
 #endif
 
+typedef uint32_t neoPixelColor;
+
 class Adafruit_NeoPixel {
 
  public:
@@ -128,7 +130,7 @@ class Adafruit_NeoPixel {
     setPin(uint8_t p),
     setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b),
     setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t w),
-    setPixelColor(uint16_t n, uint32_t c),
+    setPixelColor(uint16_t n, neoPixelColor c),
     setBrightness(uint8_t),
     clear(),
     updateLength(uint16_t n),
@@ -138,10 +140,10 @@ class Adafruit_NeoPixel {
     getBrightness(void) const;
   uint16_t
     numPixels(void) const;
-  static uint32_t
+  static neoPixelColor
     Color(uint8_t r, uint8_t g, uint8_t b),
     Color(uint8_t r, uint8_t g, uint8_t b, uint8_t w);
-  uint32_t
+  neoPixelColor
     getPixelColor(uint16_t n) const;
   inline bool
     canShow(void) { return (micros() - endTime) >= 50L; }


### PR DESCRIPTION
I created the neoPixelColor to keep the color values separated from other uint32_t. This helped straighten out a few bugs in my code.
