### PR TITLE
fix travis compiler warnings

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -36,7 +36,7 @@
 
 // Constructor when length, pin and type are known at compile-time:
 Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, neoPixelType t) :
-  brightness(0), pixels(NULL), endTime(0), begun(false)
+  begun(false), brightness(0), pixels(NULL), endTime(0)
 {
   updateType(t);
   updateLength(n);
@@ -49,11 +49,14 @@ Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, neoPixelType t) :
 // command.  If using this constructor, MUST follow up with updateType(),
 // updateLength(), etc. to establish the strand type, length and pin number!
 Adafruit_NeoPixel::Adafruit_NeoPixel() :
-  pin(-1), brightness(0), pixels(NULL), endTime(0), begun(false),
-  numLEDs(0), numBytes(0), rOffset(1), gOffset(0), bOffset(2), wOffset(1)
 #ifdef NEO_KHZ400
-  , is800KHz(true)
+  is800KHz(true),
 #endif
+  begun(false),
+  numLEDs(0), numBytes(0),
+  pin(-1), brightness(0), pixels(NULL),
+  rOffset(1), gOffset(0), bOffset(2), wOffset(1),
+  endTime(0)
 {
 }
 


### PR DESCRIPTION
This fixes these warning messages from Travis:

```
In file included from /home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.cpp:35:0:
/home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.h: In constructor 'Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t, uint8_t, neoPixelType)':
/home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.h:170:5: warning: 'Adafruit_NeoPixel::endTime' will be initialized after [-Wreorder]
     endTime;       // Latch timing reference
     ^
/home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.h:156:5: warning:   'boolean Adafruit_NeoPixel::begun' [-Wreorder]
     begun;         // true if begin() previously called
     ^
/home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.cpp:38:1: warning:   when initialized here [-Wreorder]
 Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, neoPixelType t) :
 ^
In file included from /home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.cpp:35:0:
/home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.h: In constructor 'Adafruit_NeoPixel::Adafruit_NeoPixel()':
/home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.h:170:5: warning: 'Adafruit_NeoPixel::endTime' will be initialized after [-Wreorder]
     endTime;       // Latch timing reference
     ^
/home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.h:156:5: warning:   'boolean Adafruit_NeoPixel::begun' [-Wreorder]
     begun;         // true if begin() previously called
     ^
/home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.cpp:51:1: warning:   when initialized here [-Wreorder]
 Adafruit_NeoPixel::Adafruit_NeoPixel() :
 ^
In file included from /home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.cpp:35:0:
/home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.h:168:5: warning: 'Adafruit_NeoPixel::wOffset' will be initialized after [-Wreorder]
     wOffset;       // Index of white byte (same as rOffset if no white)
     ^
/home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.h:154:5: warning:   'boolean Adafruit_NeoPixel::is800KHz' [-Wreorder]
     is800KHz,      // ...true if 800 KHz pixels
     ^
/home/travis/arduino_ide/libraries/Adafruit_Test_Library/Adafruit_NeoPixel.cpp:51:1: warning:   when initialized here [-Wreorder]
 Adafruit_NeoPixel::Adafruit_NeoPixel() :
```
