### PR TITLE
Bug fix: neoPixelType was wrong type: 400kHz now uses uint16_t and 800kHz uses uint8_t ( they were reversed)

### DIFF
--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -108,9 +108,9 @@
 // is sufficient to encode pixel color order, saving some space.
 
 #ifdef NEO_KHZ400
-typedef uint8_t  neoPixelType;
+typedef uint16_t  neoPixelType;
 #else
-typedef uint16_t neoPixelType;
+typedef uint8_t neoPixelType;
 #endif
 
 class Adafruit_NeoPixel {


### PR DESCRIPTION
 "If 400 KHz support is enabled, the third parameter to the constructor
 requires a 16-bit value (in order to select 400 vs 800 KHz speed).
 If only 800 KHz is enabled (as is default on ATtiny), an 8-bit value
 is sufficient to encode pixel color order, saving some space."

The typedef was reversed from what is necessary to support 400kHz.

This is now corrected so 400kHz now uses uint16_t and 800 uses uint8_t