### PR TITLE
Bugfix

### DIFF
--- a/examples/RGBWstrandtest/RGBW_strandtest.ino
+++ b/examples/RGBWstrandtest/RGBW_strandtest.ino
@@ -9,7 +9,7 @@
 
 #define BRIGHTNESS 50
 
-Adafruit_NeoPixel strip = _NeoPixel(NUM_LEDS, PIN, NEO_GRBW + NEO_KHZ800);
+Adafruit_NeoPixel strip = Adafruit_NeoPixel(NUM_LEDS, PIN, NEO_GRBW + NEO_KHZ800);
 
 int gamma[] = {
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,


### PR DESCRIPTION
Found an error in the code and fixed it.

Error details:
Arduino: 1.6.7 (Mac OS X), Board: "Arduino/Genuino Mega or Mega 2560, ATmega2560 (Mega 2560)"

RGBW_strandtest:12: error: '_NeoPixel' was not declared in this scope
 Adafruit_NeoPixel strip = _NeoPixel(NUM_LEDS, PIN, NEO_GRBW + NEO_KHZ800);
                                                                         ^
exit status 1
'_NeoPixel' was not declared in this scope