### PR TITLE
Added getPin accessor method

### DIFF
--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -135,7 +135,8 @@ class Adafruit_NeoPixel {
     updateType(neoPixelType t);
   uint8_t
    *getPixels(void) const,
-    getBrightness(void) const;
+    getBrightness(void) const,
+	getPin(void) { return pin };
   uint16_t
     numPixels(void) const;
   static uint32_t

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -137,7 +137,7 @@ class Adafruit_NeoPixel {
    *getPixels(void) const,
     getBrightness(void) const;
   int8_t
-	getPin(void) { return pin };
+	  getPin(void) { return pin; };
   uint16_t
     numPixels(void) const;
   static uint32_t

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -135,7 +135,8 @@ class Adafruit_NeoPixel {
     updateType(neoPixelType t);
   uint8_t
    *getPixels(void) const,
-    getBrightness(void) const,
+    getBrightness(void) const;
+  int8_t
 	getPin(void) { return pin };
   uint16_t
     numPixels(void) const;


### PR DESCRIPTION
How was this not already a thing? If you have the capacity to change the data you should be able to read what is already there. It would be helpful to have in my current projects. Which references data and functions for certain strips based on the data pin that they are connected to. It would be easier than trying to keep track of each strip's pin using an array, and require no excess memory overhead other than what's required to store this function.
