### PR TITLE
allow to specify the framebuffer from the outside.

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -34,11 +34,11 @@
 #include "Adafruit_NeoPixel.h"
 
 // Constructor when length, pin and type are known at compile-time:
-Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, neoPixelType t) :
+Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, neoPixelType t, uint8_t *pix) :
   begun(false), brightness(0), pixels(NULL), endTime(0)
 {
-  updateType(t);
-  updateLength(n);
+  updateType(t,pix);
+  updateLength(n,pix);
   setPin(p);
 }
 
@@ -69,7 +69,14 @@ void Adafruit_NeoPixel::begin(void) {
   begun = true;
 }
 
-void Adafruit_NeoPixel::updateLength(uint16_t n) {
+void Adafruit_NeoPixel::updateLength(uint16_t n, uint8_t *pix) {
+  if(pix) {
+    pixels = pix;
+    numBytes = n * ((wOffset == rOffset) ? 3 : 4);
+    memset(pixels, 0, numBytes);
+    numLEDs = n;
+    return;
+  }
   if(pixels) free(pixels); // Free existing data (if any)
 
   // Allocate new data -- note: ALL PIXELS ARE CLEARED
@@ -82,7 +89,7 @@ void Adafruit_NeoPixel::updateLength(uint16_t n) {
   }
 }
 
-void Adafruit_NeoPixel::updateType(neoPixelType t) {
+void Adafruit_NeoPixel::updateType(neoPixelType t, uint8_t *pix) {
   boolean oldThreeBytesPerPixel = (wOffset == rOffset); // false if RGBW
 
   wOffset = (t >> 6) & 0b11; // See notes in header file
@@ -97,7 +104,7 @@ void Adafruit_NeoPixel::updateType(neoPixelType t) {
   // allocated), re-allocate to new size.  Will clear any data.
   if(pixels) {
     boolean newThreeBytesPerPixel = (wOffset == rOffset);
-    if(newThreeBytesPerPixel != oldThreeBytesPerPixel) updateLength(numLEDs);
+    if(newThreeBytesPerPixel != oldThreeBytesPerPixel) updateLength(numLEDs,pix);
   }
 }
 

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -118,7 +118,7 @@ class Adafruit_NeoPixel {
  public:
 
   // Constructor: number of LEDs, pin number, LED type
-  Adafruit_NeoPixel(uint16_t n, uint8_t p=6, neoPixelType t=NEO_GRB + NEO_KHZ800);
+  Adafruit_NeoPixel(uint16_t n, uint8_t p=6, neoPixelType t=NEO_GRB + NEO_KHZ800, uint8_t *pix=NULL);
   Adafruit_NeoPixel(void);
   ~Adafruit_NeoPixel();
 
@@ -131,8 +131,8 @@ class Adafruit_NeoPixel {
     setPixelColor(uint16_t n, uint32_t c),
     setBrightness(uint8_t),
     clear(),
-    updateLength(uint16_t n),
-    updateType(neoPixelType t);
+    updateLength(uint16_t n,uint8_t *pix=NULL),
+    updateType(neoPixelType t,uint8_t *pix=NULL);
   uint8_t
    *getPixels(void) const,
     getBrightness(void) const;
@@ -147,6 +147,8 @@ class Adafruit_NeoPixel {
     getPixelColor(uint16_t n) const;
   inline bool
     canShow(void) { return (micros() - endTime) >= 50L; }
+  uint8_t
+   *pixels;        // Holds LED color values (3 or 4 bytes each)
 
  private:
 
@@ -162,7 +164,6 @@ class Adafruit_NeoPixel {
     pin;           // Output pin number (-1 if not yet set)
   uint8_t
     brightness,
-   *pixels,        // Holds LED color values (3 or 4 bytes each)
     rOffset,       // Index of red byte within each 3- or 4-byte pixel
     gOffset,       // Index of green byte
     bOffset,       // Index of blue byte


### PR DESCRIPTION
This pull request makes it possible to hand in a pointer to the framebuffer memory, so that it does not get allocated by the library itself.

This makes it possible for the application, where in the memory the framebuffer is located exactly.

Also this change makes the "pixels" member public.

To the best of my knowledge this is a backward-compatible change. I use it in https://github.com/simon-budig/flame/blob/master/flame.ino