### PR TITLE
Add HSV to RGB conversion to set pixel colors and an example

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1608,6 +1608,104 @@ void Adafruit_NeoPixel::setPixelColor(uint16_t n, uint32_t c) {
   }
 }
 
+// Set pixel color from HSV colorspace:
+// See http://www.vagrearg.org/content/hsvrgb for in depth algorithm and
+// implementation explanation.
+void Adafruit_NeoPixel::setPixelColorHsv(
+ uint16_t n, uint16_t h, uint8_t s, uint8_t v) {
+  if(n >= numLEDs)
+    return;
+
+  uint8_t r, g, b;
+
+  if(!s) {
+    // Monochromatic, all components are V
+    r = g = b = v;
+  } else {
+    uint8_t sextant = h >> 8;
+    if(sextant > 5)
+      sextant = 5;  // Limit hue sextants to defined space
+
+    g = v;    // Top level
+
+    // Perform actual calculations
+
+    /*
+     * Bottom level:
+     * --> (v * (255 - s) + error_corr + 1) / 256
+     */
+    uint16_t ww;        // Intermediate result
+    ww = v * (uint8_t)(~s);
+    ww += 1;            // Error correction
+    ww += ww >> 8;      // Error correction
+    b = ww >> 8;
+
+    uint8_t h_fraction = h & 0xff;  // Position within sextant
+    uint32_t d;      // Intermediate result
+
+    if(!(sextant & 1)) {
+      // r = ...slope_up...
+      // --> r = (v * ((255 << 8) - s * (256 - h)) + error_corr1 + error_corr2) / 65536
+      d = v * (uint32_t)(0xff00 - (uint16_t)(s * (256 - h_fraction)));
+      d += d >> 8;  // Error correction
+      d += v;       // Error correction
+      r = d >> 16;
+    } else {
+      // r = ...slope_down...
+      // --> r = (v * ((255 << 8) - s * h) + error_corr1 + error_corr2) / 65536
+      d = v * (uint32_t)(0xff00 - (uint16_t)(s * h_fraction));
+      d += d >> 8;  // Error correction
+      d += v;       // Error correction
+      r = d >> 16;
+    }
+
+    // Swap RGB values according to sextant. This is done in reverse order with
+    // respect to the original because the swaps are done after the
+    // assignments.
+    if(!(sextant & 6)) {
+      if(!(sextant & 1)) {
+        uint8_t tmp = r;
+        r = g;
+        g = tmp;
+      }
+    } else {
+      if(sextant & 1) {
+        uint8_t tmp = r;
+        r = g;
+        g = tmp;
+      }
+    }
+    if(sextant & 4) {
+      uint8_t tmp = g;
+      g = b;
+      b = tmp;
+    }
+    if(sextant & 2) {
+      uint8_t tmp = r;
+      r = b;
+      b = tmp;
+    }
+  }
+
+  // At this point, RGB values are assigned.
+
+  if(brightness) { // See notes in setBrightness()
+    r = (r * brightness) >> 8;
+    g = (g * brightness) >> 8;
+    b = (b * brightness) >> 8;
+  }
+  uint8_t *p;
+  if(wOffset == rOffset) { // Is an RGB-type strip
+    p = &pixels[n * 3];    // 3 bytes per pixel
+  } else {                 // Is a WRGB-type strip
+    p = &pixels[n * 4];    // 4 bytes per pixel
+    p[wOffset] = 0;        // But only R,G,B passed -- set W to 0
+  }
+  p[rOffset] = r;          // R,G,B always stored
+  p[gOffset] = g;
+  p[bOffset] = b;
+}
+
 // Convert separate R,G,B into packed 32-bit RGB color.
 // Packed format is always RGB, regardless of LED strand color order.
 uint32_t Adafruit_NeoPixel::Color(uint8_t r, uint8_t g, uint8_t b) {

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -113,6 +113,17 @@ typedef uint16_t neoPixelType;
 typedef uint8_t  neoPixelType;
 #endif
 
+// HSV colorspace defines delimiting the values in the call
+// to setPixelColorHsv().
+#define NEO_HSV_HUE_SEXTANT 256
+#define NEO_HSV_HUE_STEPS   (6 * NEO_HSV_HUE_SEXTANT)
+#define NEO_HSV_HUE_MIN     0
+#define NEO_HSV_HUE_MAX     (NEO_HSV_HUE_STEPS - 1)
+#define NEO_HSV_SAT_MIN     0
+#define NEO_HSV_SAT_MAX     255
+#define NEO_HSV_VAL_MIN     0
+#define NEO_HSV_VAL_MAX     255
+
 class Adafruit_NeoPixel {
 
  public:
@@ -129,6 +140,7 @@ class Adafruit_NeoPixel {
     setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b),
     setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t w),
     setPixelColor(uint16_t n, uint32_t c),
+    setPixelColorHsv(uint16_t n, uint16_t h, uint8_t s, uint8_t v),
     setBrightness(uint8_t),
     clear(),
     updateLength(uint16_t n),

--- a/examples/hsvrainbow/hsvrainbow.ino
+++ b/examples/hsvrainbow/hsvrainbow.ino
@@ -1,0 +1,100 @@
+// NeoPixel Rainbow example using HSV color-space control
+//
+// (C) 2016 B. Stultiens
+//
+// Released under the GPLv3 license to match the rest of the AdaFruit NeoPixel
+// library.
+//
+#include "Adafruit_NeoPixel.h"
+
+#define PIN_STRIP	6	// Pin for the strip of pixels
+#define NUMPIXELS	30	// Number of pixels connected
+
+#define INTERVAL	10	// 10ms update interval
+
+// Dynamic change and rate-of-change of value and color saturation. Set these
+// to zero (0) if you just want to see the rainbow in full color and no other
+// effects.
+#define VCHANGE		(-3)	// Value (intensity) change
+#define SCHANGE		(-1)	// Color saturation change
+
+#define HCHANGE		7	// Speed of the rainbow changes
+#define HUE_REVERSE_CNT	1000	// Rainbow direction reversal interval
+
+// Setup the NeoPixel library with the number of pixels, which pin to send the
+// data to and the type of LED to use. See also other examples.
+Adafruit_NeoPixel pixels = Adafruit_NeoPixel(NUMPIXELS, PIN_STRIP, NEO_GRB + NEO_KHZ800);
+
+static int16_t hue;		// Hue angle counter
+static uint8_t val;		// Current value
+static uint8_t sat;		// Current saturation
+static int8_t  hdir;		// Direction of the hue changes
+static int8_t  vdir;		// Direction of the value changes
+static int8_t  sdir;		// Direction of the saturation changes
+static uint8_t prevtime;	// Last time an update occurred
+static uint16_t hcnt;		// Hue reversal interval counter
+
+void setup()
+{
+	hue = NEO_HSV_HUE_MIN;	// Start at Hue = 0 (red)
+	val = NEO_HSV_VAL_MAX;	// Start at maximum intensity
+	sat = NEO_HSV_SAT_MAX;	// Start at full color
+	hdir = HCHANGE;		// Direction and magnitude of the hue changes
+	vdir = VCHANGE;		// Direction and magnitude of the value changes
+	sdir = SCHANGE;		// Direction and magnitude of the saturation changes
+
+	pixels.begin();		// Init the pixels
+	prevtime = millis();	// Record current time for interval timing
+	hcnt = 0;
+}
+
+void loop()
+{
+	uint8_t now = millis();
+	uint8_t tdiff = now - prevtime;
+
+	if(tdiff >= INTERVAL) {
+		prevtime = now;		// Change color every [interval] ms
+
+		// Increase global hue to circle and wrap
+		// This will create a cycling rainbow effect
+		hue += hdir;
+		if(hue > NEO_HSV_HUE_MAX)	// Wrap circle
+			hue -= NEO_HSV_HUE_MAX;
+		else if(hue < NEO_HSV_HUE_MIN)	// Wrap circle
+			hue += NEO_HSV_HUE_MAX;
+
+		// Reverse the rainbow direction
+		if(++hcnt >= HUE_REVERSE_CNT) {
+			hdir = -hdir;
+			hcnt = 0;
+		}
+
+		// Vary value between 1/3 and 3/3 of NEO_HSV_VAL_MAX
+		// This changes the overall intensity periodically
+		val += vdir;
+		if(val < NEO_HSV_VAL_MAX / 3 || val == NEO_HSV_VAL_MAX)
+			vdir = -vdir;	// Reverse value direction
+
+		// Vary saturation between 2/3 and 3/3 (full) color
+		// This makes colors appear periodically bright or pale
+		sat += sdir;
+		if(sat == NEO_HSV_SAT_MAX * 2 / 3 || sat == NEO_HSV_SAT_MAX)
+			sdir = -sdir;	// Reverse saturation direction
+
+		uint16_t h = hue;	// The global hue is the starting point of the rainbow
+
+		for(uint8_t i = 0; i < NUMPIXELS; i++) {
+			// Set pixel at fully saturated color with current value
+			pixels.setPixelColorHsv(i, h, sat, val);
+
+			// Increase local hue for each pixel to create the rainbow
+			h += 27;
+			if(h > NEO_HSV_HUE_MAX)
+				h -= NEO_HSV_HUE_MAX;
+		}
+
+		// Show the new rainbow
+		pixels.show();
+	}
+}


### PR DESCRIPTION
Implement (integer) HSV to RGB conversion with a very fast algorithm (see http://www.vagrearg.org/content/hsvrgb). Using the HSV color-space is significantly easier than the RGB color-space when gradients need to be created (f.ex. rainbows).

Added one function in the class: setPixelColorHsv() and the corresponding implementation. Defines are added to delimit the parameters' ranges. The implementation is cross-platform and should be functional for any usual platform and architecture (8-bit, 16-bit, 32-bit and 64-bit). An example is included to show its use.
