### PR TITLE
Support SAMD21J18A too (SODAQ Autonomo)

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1186,7 +1186,7 @@ void Adafruit_NeoPixel::show(void) {
 #error "Sorry, only 48 MHz is supported, please set Tools > CPU Speed to 48 MHz"
 #endif // F_CPU == 48000000
 
-#elif defined(__SAMD21G18A__) // Arduino Zero
+#elif defined(__SAMD21G18A__) || defined(__SAMD21J18A__) // Arduino Zero, SODAQ Autonomo and others
 
   // Tried this with a timer/counter, couldn't quite get adequate
   // resolution.  So yay, you get a load of goofball NOPs...


### PR DESCRIPTION
Add support for another SAMD21 variant

This was tested on a SODAQ Autonomo which has a SAMD21J18A