### PR TITLE
Make example compatible with Trinket

### DIFF
--- a/examples/RGBWstrandtest/RGBWstrandtest.ino
+++ b/examples/RGBWstrandtest/RGBWstrandtest.ino
@@ -11,7 +11,7 @@
 
 Adafruit_NeoPixel strip = Adafruit_NeoPixel(NUM_LEDS, PIN, NEO_GRBW + NEO_KHZ800);
 
-int gamma[] = {
+byte gamma[] = {
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  1,  1,  1,
     1,  1,  1,  1,  1,  1,  1,  1,  1,  2,  2,  2,  2,  2,  2,  2,
@@ -31,7 +31,7 @@ int gamma[] = {
 
 
 void setup() {
-  Serial.begin(115200);
+  // Serial.begin(115200);
   // This is for Trinket 5V 16MHz, you can remove these three lines if you are not using a Trinket
   #if defined (__AVR_ATtiny85__)
     if (F_CPU == 16000000) clock_prescale_set(clock_div_1);


### PR DESCRIPTION
Removed Serial initialization - not needed and not working with Trinket
Changed array type from "int" to "byte" to fit in Atttiny85's Trinket.