### PR TITLE
Fixed overflow issue with getPixelColor

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1634,9 +1634,9 @@ uint32_t Adafruit_NeoPixel::getPixelColor(uint16_t n) const {
       // value used when setting the pixel color, but there will always be
       // some error -- those bits are simply gone.  Issue is most
       // pronounced at low brightness levels.
-      return (((uint32_t)(p[rOffset] << 8) / brightness) << 16) |
-             (((uint32_t)(p[gOffset] << 8) / brightness) <<  8) |
-             ( (uint32_t)(p[bOffset] << 8) / brightness       );
+      return ((uint32_t)((uint16_t)(p[rOffset] << 8) / brightness) << 16) |
+             ((uint32_t)((uint16_t)(p[gOffset] << 8) / brightness) <<  8) |
+              (uint32_t)((uint16_t)(p[bOffset] << 8) / brightness       );
     } else {
       // No brightness adjustment has been made -- return 'raw' color
       return ((uint32_t)p[rOffset] << 16) |
@@ -1646,10 +1646,10 @@ uint32_t Adafruit_NeoPixel::getPixelColor(uint16_t n) const {
   } else {                 // Is RGBW-type device
     p = &pixels[n * 4];
     if(brightness) { // Return scaled color
-      return (((uint32_t)(p[wOffset] << 8) / brightness) << 24) |
-             (((uint32_t)(p[rOffset] << 8) / brightness) << 16) |
-             (((uint32_t)(p[gOffset] << 8) / brightness) <<  8) |
-             ( (uint32_t)(p[bOffset] << 8) / brightness       );
+      return ((uint32_t)((uint16_t)(p[wOffset] << 8) / brightness) << 24) |
+             ((uint32_t)((uint16_t)(p[rOffset] << 8) / brightness) << 16) |
+             ((uint32_t)((uint16_t)(p[gOffset] << 8) / brightness) <<  8) |
+              (uint32_t)((uint16_t)(p[bOffset] << 8) / brightness       );
     } else { // Return raw color
       return ((uint32_t)p[wOffset] << 24) |
              ((uint32_t)p[rOffset] << 16) |


### PR DESCRIPTION
This is an update to fix the issue described [here](https://forums.adafruit.com/viewtopic.php?f=47&t=106100).

**Describe the scope of your change**: 
Added (uint16_t) data type conversion to the brightness correction of the getPixelColor function so that it works properly and avoids overflow.

When the product of a channel's color value and the current brightness level is greater than 2<sup>15</sup> (i.e. the upper bound of a signed 16-bit type) the output of the function is erratic. When the product drops below 2<sup>15</sup>, either due to a lower input value or a lower brightness level, the function's output behaves normally. The solution is to force an unsigned conversion.

I'm using the Arduino IDE (1.6.9) and I've verified the problem with several compilers. This change appears to fix it entirely. I've tested both the RGB and RGBW functions and haven't found any issues.

**Describe any known limitations with your change**:
None.

**Please run any tests or examples that can exercise your modified code.**
I put together a test sketch to demonstrate the problem. [You can find the sketch and the output (pre and post fix) here](https://github.com/dmadison/Adafruit_NeoPixel/tree/getPixelColor-fix-examples/getPixelColor_Test). The test checks both RGB and RGBW strips with three separate input levels and data arrangement.

For the text the sketch was compiled to an Arduino Uno using the 1.6.9 IDE and the AVRISPmkII programmer.
