### PR TITLE
Neopixel silently does nothing on non supported architectures

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1511,7 +1511,9 @@ void Adafruit_NeoPixel::show(void) {
       first = 0;
     }
   }
-
+#else
+// ESP32 and others not currently working
+#error Sorry your architecture is not supported
 #endif
 
 


### PR DESCRIPTION
After troubleshooting on an ESP32 and wondering why it wasn't working, I realized that due to nested ifdefs (hard to see initially), no code was actually being run for that processor.
Since there is no C fallback that works everywhere due to timing issues, add a compile error to save time to the end user.
