### PR TITLE
Added public isRGBType()

### DIFF
--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -133,6 +133,8 @@ class Adafruit_NeoPixel {
     clear(),
     updateLength(uint16_t n),
     updateType(neoPixelType t);
+  bool
+  	isRGBType(void);
   uint8_t
    *getPixels(void) const,
     getBrightness(void) const;


### PR DESCRIPTION
This allows color libraries to know what type, 3 or 4 color LEDs, they
are dealing with. Now they can make better choices about how to deal
with them. Also, localizes the knowledge in the library itself.