### PR TITLE
Rgbwstrandfix

### DIFF
--- a/examples/RGBWstrandtest/RGBWstrandtest.ino
+++ b/examples/RGBWstrandtest/RGBWstrandtest.ino
@@ -89,22 +89,22 @@ void pulseWhite(uint8_t wait) {
 
 
 void rainbowFade2White(uint8_t wait, int rainbowLoops, int whiteLoops) {
-  float fadeMax = 100.0;
-  int fadeVal = 0;
+  const unsigned fadeMax = 100;
+  unsigned fadeVal = 0;
   uint32_t wheelVal;
-  int redVal, greenVal, blueVal;
+  uint8_t redVal, greenVal, blueVal;
 
   for(int k = 0 ; k < rainbowLoops ; k ++){
     
-    for(int j=0; j<256; j++) { // 5 cycles of all colors on wheel
+    for(unsigned j=0; j<256; j++) { // 5 cycles of all colors on wheel
 
       for(unsigned i=0; i< strip.numPixels(); i++) {
 
         wheelVal = Wheel(((i * 256 / strip.numPixels()) + j) & 255);
 
-        redVal = red(wheelVal) * float(fadeVal/fadeMax);
-        greenVal = green(wheelVal) * float(fadeVal/fadeMax);
-        blueVal = blue(wheelVal) * float(fadeVal/fadeMax);
+        redVal = (uint16_t)red(wheelVal) * fadeVal / fadeMax;
+        greenVal = (uint16_t)green(wheelVal) * fadeVal / fadeMax;
+        blueVal = (uint16_t)blue(wheelVal) * fadeVal / fadeMax;
 
         strip.setPixelColor( i, strip.Color( redVal, greenVal, blueVal ) );
 

--- a/examples/RGBWstrandtest/RGBWstrandtest.ino
+++ b/examples/RGBWstrandtest/RGBWstrandtest.ino
@@ -98,7 +98,7 @@ void rainbowFade2White(uint8_t wait, int rainbowLoops, int whiteLoops) {
     
     for(int j=0; j<256; j++) { // 5 cycles of all colors on wheel
 
-      for(int i=0; i< strip.numPixels(); i++) {
+      for(unsigned i=0; i< strip.numPixels(); i++) {
 
         wheelVal = Wheel(((i * 256 / strip.numPixels()) + j) & 255);
 
@@ -160,8 +160,8 @@ void whiteOverRainbow(uint8_t wait, uint8_t whiteSpeed, uint8_t whiteLength ) {
   
   if(whiteLength >= strip.numPixels()) whiteLength = strip.numPixels() - 1;
 
-  int head = whiteLength - 1;
-  int tail = 0;
+  unsigned head = whiteLength - 1;
+  unsigned tail = 0;
 
   int loops = 3;
   int loopNum = 0;


### PR DESCRIPTION
- Fix signed/unsigned comparison warnings in the RGBWStrandTest example.
- Do not use floating point. Calculations can be performed using integer calculations
- Do not run Travis CI on the (attiny85) trinket.

Removal of the floating point use makes the code compatible with the attiny85 trinket by reducing the code-size (from 103% to 84%). However, it cannot be compiled in one pass. The Arduino IDE can compile the example successfully, but the sketch must be compiled twice.

The reason for the compile problem is a conflict due to a name-collision of a #define between the Arduino libraries and the standard avr include files. The define of "BIN" is conflicting in Arduino's Print.h header file, which cannot be solved easily (or at all) without altering the Arduino libraries (see also issue #118). The define is part of the serial print code, which is moot for the attiny85 based trinket.

The Ardiuno IDE ignores the errors on second compile (as long as you do not change the target board) because it has created a local cache-library of the core Arduino libraries. However, this does not work for Travis CI, because it will "see" the error on first compile and bail out. Therefore, the test must be disabled in the git repo, but the example is still functional.
