### PR TITLE
Added support for the Arduino Tau from Rabid Prototypes

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1487,7 +1487,7 @@ void Adafruit_NeoPixel::show(void) {
   }
 // END of NRF52 implementation
 
-#elif defined(__SAMD21G18A__)  || defined(__SAMD21E18A__) || defined(__SAMD21J18A__) // Arduino Zero, Gemma/Trinket M0, SODAQ Autonomo and others
+#elif defined (__SAMD21E17A__) || defined(__SAMD21G18A__)  || defined(__SAMD21E18A__) || defined(__SAMD21J18A__) // Arduino Zero, Gemma/Trinket M0, SODAQ Autonomo and others
   // Tried this with a timer/counter, couldn't quite get adequate
   // resolution.  So yay, you get a load of goofball NOPs...
 


### PR DESCRIPTION
Added support for the Arduino Tau from Rabid Prototypes:
http://rabidprototypes.com/product/tau/

All that was necessary was to add the correct version of SAMD processor,
SAMD21E17A, in addition to the existing SAMD21x18A.

The modified code runs fine on the Arduino Tau.