### PR TITLE
correcting typo in comment

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -130,7 +130,7 @@ void Adafruit_NeoPixel::show(void) {
   // allows the mainline code to start generating the next frame of data
   // rather than stalling for the latch.
   while(!canShow());
-  // endTime is a private member (rather than global var) so that mutliple
+  // endTime is a private member (rather than global var) so that multiple
   // instances on different pins can be quickly issued in succession (each
   // instance doesn't delay the next).
 


### PR DESCRIPTION
corrected spelling of 'multiple' in comment. No changes in code.
