### PR TITLE
Repeat pixel array for nearly infinite LED strings with limited RAM

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -163,7 +163,8 @@ void Adafruit_NeoPixel::show(void) {
    *ptr = pixels,   // Pointer to next byte
     b   = *ptr++,   // Current byte value
     hi,             // PORT w/output bit set high
-    lo;             // PORT w/output bit set low
+    lo,             // PORT w/output bit set low
+    reps = repeats; // how many times to repeat
 
   // Hand-tuned assembly code issues data to the LED drivers at a specific
   // rate.  There's separate code for different CPU speeds (8, 12, 16 MHz)
@@ -960,6 +961,7 @@ void Adafruit_NeoPixel::show(void) {
     next = lo;
     bit  = 8;
 
+    while (reps--) { // repeat for the number of strings wired in series
     asm volatile(
      "head20:"                   "\n\t" // Clk  Pseudocode    (T =  0)
       "st   %a[port],  %[hi]"    "\n\t" // 2    PORT = hi     (T =  2)
@@ -991,6 +993,7 @@ void Adafruit_NeoPixel::show(void) {
       : [ptr]    "e" (ptr),
         [hi]     "r" (hi),
         [lo]     "r" (lo));
+    } // while (reps--)
 
 #ifdef NEO_KHZ400
   } else { // 400 KHz

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -42,12 +42,13 @@
 #endif
 
 // Constructor when length, pin and type are known at compile-time:
-Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, neoPixelType t) :
+Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, neoPixelType t, uint8_t r) :
   begun(false), brightness(0), pixels(NULL), endTime(0)  
 {
   updateType(t);
   updateLength(n);
   setPin(p);
+  updateRepeats(r);
 }
 
 // via Michael Vogt/neophob: empty constructor is used when strand length
@@ -60,7 +61,7 @@ Adafruit_NeoPixel::Adafruit_NeoPixel() :
   is800KHz(true),
 #endif
   begun(false), numLEDs(0), numBytes(0), pin(-1), brightness(0), pixels(NULL),
-  rOffset(1), gOffset(0), bOffset(2), wOffset(1), endTime(0)
+  rOffset(1), gOffset(0), bOffset(2), wOffset(1), repeats(1), endTime(0)
 {
 }
 
@@ -89,6 +90,10 @@ void Adafruit_NeoPixel::updateLength(uint16_t n) {
   } else {
     numLEDs = numBytes = 0;
   }
+}
+
+void Adafruit_NeoPixel::updateRepeats(uint8_t r) {
+  repeats = r; // set how many sets of LEDs are wired in series data-wise (see ::show(void))
 }
 
 void Adafruit_NeoPixel::updateType(neoPixelType t) {

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -962,6 +962,9 @@ void Adafruit_NeoPixel::show(void) {
     bit  = 8;
 
     while (reps--) { // repeat for the number of strings wired in series
+      ptr = pixels; // reset pointer to beginning of array
+      b   = *ptr++;   // reset Current byte value
+      i   = numBytes; // reset Loop counter
     asm volatile(
      "head20:"                   "\n\t" // Clk  Pseudocode    (T =  0)
       "st   %a[port],  %[hi]"    "\n\t" // 2    PORT = hi     (T =  2)

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -118,7 +118,7 @@ class Adafruit_NeoPixel {
  public:
 
   // Constructor: number of LEDs, pin number, LED type
-  Adafruit_NeoPixel(uint16_t n, uint8_t p=6, neoPixelType t=NEO_GRB + NEO_KHZ800);
+  Adafruit_NeoPixel(uint16_t n, uint8_t p=6, neoPixelType t=NEO_GRB + NEO_KHZ800, uint8_t r=0);
   Adafruit_NeoPixel(void);
   ~Adafruit_NeoPixel();
 
@@ -132,6 +132,7 @@ class Adafruit_NeoPixel {
     setBrightness(uint8_t),
     clear(),
     updateLength(uint16_t n),
+    updateRepeats(uint8_t r),
     updateType(neoPixelType t);
   uint8_t
    *getPixels(void) const,
@@ -166,7 +167,8 @@ class Adafruit_NeoPixel {
     rOffset,       // Index of red byte within each 3- or 4-byte pixel
     gOffset,       // Index of green byte
     bOffset,       // Index of blue byte
-    wOffset;       // Index of white byte (same as rOffset if no white)
+    wOffset,       // Index of white byte (same as rOffset if no white)
+    repeats;       // how many copies of this string are wired in series to the same data path
   uint32_t
     endTime;       // Latch timing reference
 #ifdef __AVR__

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -118,7 +118,7 @@ class Adafruit_NeoPixel {
  public:
 
   // Constructor: number of LEDs, pin number, LED type
-  Adafruit_NeoPixel(uint16_t n, uint8_t p=6, neoPixelType t=NEO_GRB + NEO_KHZ800, uint8_t r=0);
+  Adafruit_NeoPixel(uint16_t n, uint8_t p=6, neoPixelType t=NEO_GRB + NEO_KHZ800, uint8_t r=1);
   Adafruit_NeoPixel(void);
   ~Adafruit_NeoPixel();
 


### PR DESCRIPTION
These changes allow addressing over 100,000 WS2812 LEDs from a normal ATMega328, by adding a "repeats" parameter to the Adafruit_NeoPixel initializer.  For example, if you have 1000 LEDs but only enough RAM for 100 LEDs, you can set a pattern of 100 LEDs and a "repeats" of 10, and it will control all 1000 LEDs.

These changes have been made only to the 16 MHz(ish) AVR implementation of ::show(void)

Adding the same functionality to the other implementations can be done in a style agreeable to the merging parties, everyone likes things done their own way :)

This code has been tested and seems to work properly (and is backwards compatible :)

I understand this PR is not 100% complete and my style may be imperfect, but i think a lot of users out there would benefit greatly by being able to control unlimited-length LED strings without using up any more RAM than the size of their desired repeating pattern.  Or has someone else already made this?

-jerkey