### PR TITLE
Prevent copy and assignment of Adafruit_NeoPixel class

### DIFF
--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -177,6 +177,12 @@ class Adafruit_NeoPixel {
   uint8_t
     pinMask;       // Output PORT bitmask
 #endif
+
+  private:
+   // Disallow copy and assign, since the default operators do not
+   // correctly handle our pixels buffer.
+   Adafruit_NeoPixel(Adafruit_NeoPixel const&);
+   Adafruit_NeoPixel& operator=(Adafruit_NeoPixel const&);
 };
 
 #endif // ADAFRUIT_NEOPIXEL_H


### PR DESCRIPTION
Typical code which copies the neopixel class will lead to use of free()'d memory, leading to crashes and odd behaviour.

Eg.

Adafruit_NeoPixel a;
a = Adafruit_NeoPixel(100);
a.begin();
a.show();

This appears to work, but the pixels buffer is freed on the assignment line, since the right hand side is a temporary, which then gets assigned to a, and then destroyed.  The destructor frees the pixels buffer, thich is shared by and still in use by a.

We could resolve this by making an explicit copy/assign constructor which copies the pixels buffer, but considering this library runs on embedded devices, the buffer is large, and copying the neopixels library probably isn't intentional, instead this PR simply denies copying by making the copy constructor private.

We do not use the C++11 syntax to allow this to run even on very old arduino versions.