### PR TITLE
adding getPixelLuminance() function

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -2120,6 +2120,28 @@ uint32_t Adafruit_NeoPixel::getPixelColor(uint16_t n) const {
   }
 }
 
+// Returns the for the aproximate relitive lumanance of the selected pixel. 
+float Adafruit_NeoPixel::getPixelLuminance(uint16_t n) const {
+	if (n >= numLEDs) return 0; // Out of bounds, return no luminance.
+
+	if (wOffset != rOffset) return 0; // Not sure how to deal with RGBW yet.
+	
+	// Grab the brightness adjusted pixel color
+	uint32_t c = getPixelColor(n);
+
+	uint8_t r = (uint8_t)(c >> 16),
+			g = (uint8_t)(c >> 8),
+			b = (uint8_t)c;
+
+	// Calculate our pixel Luminance https://en.wikipedia.org/wiki/Relative_luminance
+	float rL = (r / 255.0) * 0.2126;
+	float gL = (g / 255.0) * 0.7152;
+	float bL = (b / 255.0) * 0.0722;
+
+	// add up all of our values and return them.
+	return (rL + gL + bL);
+}
+
 // Returns pointer to pixels[] array.  Pixel data is stored in device-
 // native format and is not translated here.  Application will need to be
 // aware of specific pixel data format and handle colors appropriately.

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -147,6 +147,8 @@ class Adafruit_NeoPixel {
     Color(uint8_t r, uint8_t g, uint8_t b, uint8_t w);
   uint32_t
     getPixelColor(uint16_t n) const;
+  float
+    getPixelLuminance(uint16t n) const;
   inline bool
     canShow(void) { return (micros() - endTime) >= 300L; }
 


### PR DESCRIPTION
Returns a float from 0.0-1.0 representing the relative luminance (or brightness) of a pixel based on the intensity perceived by humans.

In this case a green LED is preserved as "brighter" than a red or blue LEDs.

Limitations:
- Returns zero when in RGBW mode
- Calls getPixelColor() to calculate the pixel values based on brightness


Test:
  ```
strip.setPixelColor(0, strip.Color(255,0,0));
  strip.setPixelColor(1, strip.Color(0,255,0));
  strip.setPixelColor(2, strip.Color(0,0,255));
  strip.setPixelColor(3, strip.Color(0,0,0));
  strip.setPixelColor(4, strip.Color(64,64,64));
  strip.setPixelColor(5, strip.Color(127,127,127));
  strip.setPixelColor(6, strip.Color(192,192,192));
  strip.setPixelColor(7, strip.Color(255,255,255));
  strip.show();
  
  Serial.print("  red:" + strip.getPixelLuminance(0));
  Serial.print("green:" + strip.getPixelLuminance(1));
  Serial.print(" blue:" + strip.getPixelLuminance(2));
  Serial.print("   0%:" + strip.getPixelLuminance(3));
  Serial.print("  25%:" + strip.getPixelLuminance(4));
  Serial.print("  50%:" + strip.getPixelLuminance(5));
  Serial.print("  75%:" + strip.getPixelLuminance(6));
  Serial.print(" 100%:" + strip.getPixelLuminance(7));
```

Results:
```
  red:0.21
green:0.72
 blue:0.07
   0%:0.00
  25%:0.25
  50%:0.50
  75%:0.75
 100%:1.00
```