### PR TITLE
Added kendryte k210 support

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -177,6 +177,10 @@ extern "C" void espShow(
   uint8_t pin, uint8_t *pixels, uint32_t numBytes, uint8_t type);
 #endif // ESP8266
 
+#if defined(KENDRYTE_K210)
+extern "C" void ICACHE_RAM_ATTR k210Show(
+    uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz);
+#endif //KENDRYTE_K210
 /*!
   @brief   Transmit pixel data in RAM to NeoPixels.
   @note    On most architectures, interrupts are temporarily disabled in
@@ -1952,6 +1956,10 @@ void Adafruit_NeoPixel::show(void) {
   // ESP8266 show() is external to enforce ICACHE_RAM_ATTR execution
   espShow(pin, pixels, numBytes, is800KHz);
 
+#elif defined(KENDRYTE_K210)
+
+  k210Show(pin, pixels, numBytes, is800KHz);
+  
 #elif defined(__ARDUINO_ARC__)
 
 // Arduino 101  -----------------------------------------------------------

--- a/kendyte_k210.c
+++ b/kendyte_k210.c
@@ -1,0 +1,70 @@
+// This is a mash-up of the Due show() code + insights from Michael Miller's
+// ESP8266 work for the NeoPixelBus library: github.com/Makuna/NeoPixelBus
+// Needs to be a separate .c file to enforce ICACHE_RAM_ATTR execution.
+#define KENDRYTE_K210 1
+#if defined(KENDRYTE_K210)
+
+#include <Arduino.h>
+
+void ICACHE_RAM_ATTR k210Show(
+    uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz)
+{
+
+#define CYCLES_800_T0H (sysctl_clock_get_freq(SYSCTL_CLOCK_CPU) / 2500000) // 0.4us
+#define CYCLES_800_T1H (sysctl_clock_get_freq(SYSCTL_CLOCK_CPU) / 1250000) // 0.8us
+#define CYCLES_800 (sysctl_clock_get_freq(SYSCTL_CLOCK_CPU) / 800000)      // 1.25us per bit
+#define CYCLES_400_T0H (sysctl_clock_get_freq(SYSCTL_CLOCK_CPU) / 2000000) // 0.5uS
+#define CYCLES_400_T1H (sysctl_clock_get_freq(SYSCTL_CLOCK_CPU) / 833333)  // 1.2us
+#define CYCLES_400 (sysctl_clock_get_freq(SYSCTL_CLOCK_CPU) / 400000)      // 2.5us per bit
+
+    uint8_t *p, *end, pix, mask;
+    uint32_t t, time0, time1, period, c, startTime;
+
+    p = pixels;
+    end = p + numBytes;
+    pix = *p++;
+    mask = 0x80;
+    startTime = 0;
+
+#ifdef NEO_KHZ400
+    if (is800KHz)
+    {
+#endif
+        time0 = CYCLES_800_T0H;
+        time1 = CYCLES_800_T1H;
+        period = CYCLES_800;
+#ifdef NEO_KHZ400
+    }
+    else
+    { // 400 KHz bitstream
+        time0 = CYCLES_400_T0H;
+        time1 = CYCLES_400_T1H;
+        period = CYCLES_400;
+    }
+#endif
+
+    for (t = time0;; t = time0)
+    {
+        if (pix & mask)
+            t = time1; // Bit high duration
+        while (((c = read_cycle()) - startTime) < period)
+            ; // Wait for bit start
+        digitalWrite(pin, HIGH);
+        startTime = c; // Save start time
+        while (((c = read_cycle()) - startTime) < t)
+            ; // Wait high duration
+        digitalWrite(pin, LOW);
+
+        if (!(mask >>= 1))
+        { // Next bit/byte
+            if (p >= end)
+                break;
+            pix = *p++;
+            mask = 0x80;
+        }
+    }
+    while ((read_cycle() - startTime) < period)
+        ; // Wait for last bit
+}
+
+#endif // KENDRYTE_K210


### PR DESCRIPTION
Modified library so that it refuses to build on an unknown architecture
instead of building and then doing nothing.

Added kendryte k210 support, which might not be optimal, but works for me.
Test with  Seeed's https://github.com/Seeed-Studio/ArduinoCore-k210/ and
Sipeed Maix Bit board

