### PR TITLE
Change pin arguments to 16 bits from at for 32 bit uC compatibility 

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -171,10 +171,10 @@ void Adafruit_NeoPixel::updateType(neoPixelType t) {
 #if defined(ESP8266)
 // ESP8266 show() is external to enforce ICACHE_RAM_ATTR execution
 extern "C" void ICACHE_RAM_ATTR espShow(
-  uint8_t pin, uint8_t *pixels, uint32_t numBytes, uint8_t type);
+  uint16_t pin, uint8_t *pixels, uint32_t numBytes, uint8_t type);
 #elif defined(ESP32)
 extern "C" void espShow(
-  uint8_t pin, uint8_t *pixels, uint32_t numBytes, uint8_t type);
+  uint16_t pin, uint8_t *pixels, uint32_t numBytes, uint8_t type);
 #endif // ESP8266
 
 /*!

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -65,7 +65,7 @@
               pixel.
   @return  Adafruit_NeoPixel object. Call the begin() function before use.
 */
-Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, unit16_t p, neoPixelType t) :
+Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint16_t p, neoPixelType t) :
   begun(false), brightness(0), pixels(NULL), endTime(0) {
   updateType(t);
   updateLength(n);
@@ -2114,7 +2114,7 @@ void Adafruit_NeoPixel::show(void) {
            if any, is set to INPUT and the new pin is set to OUTPUT.
   @param   p  Arduino pin number (-1 = no pin).
 */
-void Adafruit_NeoPixel::setPin(unit16_t p) {
+void Adafruit_NeoPixel::setPin(uint16_t p) {
   if(begun && (pin >= 0)) pinMode(pin, INPUT);
     pin = p;
     if(begun) {

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -45,6 +45,10 @@
 
 #include "Adafruit_NeoPixel.h"
 
+#ifdef TARGET_LPC1768
+  #include <time.h>
+#endif
+
 #if defined(NRF52) || defined(NRF52_SERIES)
 #include "nrf.h"
 
@@ -1830,6 +1834,50 @@ void Adafruit_NeoPixel::show(void) {
             "nop; nop; nop; nop; nop; nop; nop; nop;"
             "nop; nop; nop; nop; nop; nop; nop; nop;"
             "nop; nop; nop; nop;");
+      }
+      if(bitMask >>= 1) {
+        // Move on to the next pixel
+        asm("nop;");
+      } else {
+        if(ptr >= end) break;
+        p       = *ptr++;
+        bitMask = 0x80;
+      }
+    }
+#ifdef NEO_KHZ400
+  } else { // 400 KHz bitstream
+    // ToDo!
+  }
+#endif
+
+#elif defined(TARGET_LPC1768)
+  uint8_t  *ptr, *end, p, bitMask;
+  ptr     =  pixels;
+  end     =  ptr + numBytes;
+  p       = *ptr++;
+  bitMask =  0x80;
+
+#ifdef NEO_KHZ400 // 800 KHz check needed only if 400 KHz support enabled
+  if(is800KHz) {
+#endif
+    for(;;) {
+      if(p & bitMask) {
+        // data ONE high
+        // min: 550 typ: 700 max: 5,500
+        gpio_set(pin);
+        time::delay_ns(550);
+        // min: 450 typ: 600 max: 5,000
+        gpio_clear(pin);
+        time::delay_ns(450);
+      } else {
+        // data ZERO high
+        // min: 200  typ: 350 max: 500
+        gpio_set(pin);
+        time::delay_ns(200);
+        // data low
+        // min: 450 typ: 600 max: 5,000
+        gpio_clear(pin);
+        time::delay_ns(450);
       }
       if(bitMask >>= 1) {
         // Move on to the next pixel

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -171,10 +171,10 @@ void Adafruit_NeoPixel::updateType(neoPixelType t) {
 #if defined(ESP8266)
 // ESP8266 show() is external to enforce ICACHE_RAM_ATTR execution
 extern "C" void ICACHE_RAM_ATTR espShow(
-  uint16_t pin, uint8_t *pixels, uint32_t numBytes, uint8_t type);
+  uint8_t pin, uint8_t *pixels, uint32_t numBytes, uint8_t type);
 #elif defined(ESP32)
 extern "C" void espShow(
-  uint16_t pin, uint8_t *pixels, uint32_t numBytes, uint8_t type);
+  uint8_t pin, uint8_t *pixels, uint32_t numBytes, uint8_t type);
 #endif // ESP8266
 
 /*!

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -65,7 +65,7 @@
               pixel.
   @return  Adafruit_NeoPixel object. Call the begin() function before use.
 */
-Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint8_t p, neoPixelType t) :
+Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, unit16_t p, neoPixelType t) :
   begun(false), brightness(0), pixels(NULL), endTime(0) {
   updateType(t);
   updateLength(n);
@@ -2114,7 +2114,7 @@ void Adafruit_NeoPixel::show(void) {
            if any, is set to INPUT and the new pin is set to OUTPUT.
   @param   p  Arduino pin number (-1 = no pin).
 */
-void Adafruit_NeoPixel::setPin(uint8_t p) {
+void Adafruit_NeoPixel::setPin(unit16_t p) {
   if(begun && (pin >= 0)) pinMode(pin, INPUT);
     pin = p;
     if(begun) {

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -195,14 +195,14 @@ class Adafruit_NeoPixel {
  public:
 
   // Constructor: number of LEDs, pin number, LED type
-  Adafruit_NeoPixel(uint16_t n, uint8_t pin=6,
+  Adafruit_NeoPixel(uint16_t n, unit16_t pin=6,
     neoPixelType type=NEO_GRB + NEO_KHZ800);
   Adafruit_NeoPixel(void);
   ~Adafruit_NeoPixel();
 
   void              begin(void);
   void              show(void);
-  void              setPin(uint8_t p);
+  void              setPin(unit16_t p);
   void              setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b);
   void              setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b,
                       uint8_t w);

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -36,11 +36,17 @@
 #ifndef ADAFRUIT_NEOPIXEL_H
 #define ADAFRUIT_NEOPIXEL_H
 
-#if (ARDUINO >= 100)
- #include <Arduino.h>
-#else
- #include <WProgram.h>
- #include <pins_arduino.h>
+#ifdef ARDUINO
+  #if (ARDUINO >= 100)
+  #include <Arduino.h>
+  #else
+  #include <WProgram.h>
+  #include <pins_arduino.h>
+  #endif
+#endif
+
+#ifdef TARGET_LPC1768
+  #include <Arduino.h>
 #endif
 
 // The order of primary colors in the NeoPixel data stream can vary among

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -195,14 +195,14 @@ class Adafruit_NeoPixel {
  public:
 
   // Constructor: number of LEDs, pin number, LED type
-  Adafruit_NeoPixel(uint16_t n, unit16_t pin=6,
+  Adafruit_NeoPixel(uint16_t n, uint16_t pin=6,
     neoPixelType type=NEO_GRB + NEO_KHZ800);
   Adafruit_NeoPixel(void);
   ~Adafruit_NeoPixel();
 
   void              begin(void);
   void              show(void);
-  void              setPin(unit16_t p);
+  void              setPin(uint16_t p);
   void              setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b);
   void              setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b,
                       uint8_t w);
@@ -246,7 +246,7 @@ class Adafruit_NeoPixel {
     @brief   Retrieve the pin number used for NeoPixel data output.
     @return  Arduino pin number (-1 if not set).
   */
-  int8_t            getPin(void) const { return pin; };
+  int16_t            getPin(void) const { return pin; };
   /*!
     @brief   Return the number of pixels in an Adafruit_NeoPixel strip object.
     @return  Pixel count (0 if not set).
@@ -334,7 +334,7 @@ class Adafruit_NeoPixel {
   boolean           begun;      ///< true if begin() previously called
   uint16_t          numLEDs;    ///< Number of RGB LEDs in strip
   uint16_t          numBytes;   ///< Size of 'pixels' buffer below
-  int8_t            pin;        ///< Output pin number (-1 if not yet set)
+  int16_t            pin;        ///< Output pin number (-1 if not yet set)
   uint8_t           brightness; ///< Strip brightness 0-255 (stored as +1)
   uint8_t          *pixels;     ///< Holds LED color values (3 or 4 bytes each)
   uint8_t           rOffset;    ///< Red index within each 3- or 4-byte pixel

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -246,7 +246,7 @@ class Adafruit_NeoPixel {
     @brief   Retrieve the pin number used for NeoPixel data output.
     @return  Arduino pin number (-1 if not set).
   */
-  int16_t            getPin(void) const { return pin; };
+  int8_t            getPin(void) const { return pin; };
   /*!
     @brief   Return the number of pixels in an Adafruit_NeoPixel strip object.
     @return  Pixel count (0 if not set).
@@ -334,7 +334,7 @@ class Adafruit_NeoPixel {
   boolean           begun;      ///< true if begin() previously called
   uint16_t          numLEDs;    ///< Number of RGB LEDs in strip
   uint16_t          numBytes;   ///< Size of 'pixels' buffer below
-  int16_t            pin;        ///< Output pin number (-1 if not yet set)
+  int8_t            pin;        ///< Output pin number (-1 if not yet set)
   uint8_t           brightness; ///< Strip brightness 0-255 (stored as +1)
   uint8_t          *pixels;     ///< Holds LED color values (3 or 4 bytes each)
   uint8_t           rOffset;    ///< Red index within each 3- or 4-byte pixel

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -246,7 +246,7 @@ class Adafruit_NeoPixel {
     @brief   Retrieve the pin number used for NeoPixel data output.
     @return  Arduino pin number (-1 if not set).
   */
-  int8_t            getPin(void) const { return pin; };
+  int16_t            getPin(void) const { return pin; };
   /*!
     @brief   Return the number of pixels in an Adafruit_NeoPixel strip object.
     @return  Pixel count (0 if not set).
@@ -334,7 +334,7 @@ class Adafruit_NeoPixel {
   boolean           begun;      ///< true if begin() previously called
   uint16_t          numLEDs;    ///< Number of RGB LEDs in strip
   uint16_t          numBytes;   ///< Size of 'pixels' buffer below
-  int8_t            pin;        ///< Output pin number (-1 if not yet set)
+  int16_t            pin;        ///< Output pin number (-1 if not yet set)
   uint8_t           brightness; ///< Strip brightness 0-255 (stored as +1)
   uint8_t          *pixels;     ///< Holds LED color values (3 or 4 bytes each)
   uint8_t           rOffset;    ///< Red index within each 3- or 4-byte pixel


### PR DESCRIPTION
There really isn't much to say about this PR. I have setup a 3d printer using the LPC1768 microcontroller using Marlin. Marlin uses this code for the Neopixels. It doesn't work with the pin being an 8 bit value. So this changes them to 16 bit values. 
