### PR TITLE
Add STM32 core support

### DIFF
--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -352,6 +352,10 @@ class Adafruit_NeoPixel {
   volatile uint8_t *port;       ///< Output PORT register
   uint8_t           pinMask;    ///< Output PORT bitmask
 #endif
+#ifdef ARDUINO_ARCH_STM32
+  GPIO_TypeDef *gpioPort;       ///< Output GPIO PORT
+  uint32_t gpioPin;             ///< Output GPIO PIN
+#endif
 };
 
 #endif // ADAFRUIT_NEOPIXEL_H


### PR DESCRIPTION
Hi,

this PR add the [STM32](https://github.com/stm32duino/Arduino_Core_STM32) core support to the library.

All added codes are under `ARDUINO_ARCH_STM32` define.

It was tested with the [NeoPixel Ring - 16 x 5050 RGB LED with Integrated Drivers] (https://www.adafruit.com/product/1463) on following STM32 based boards:

* Nucleo F091RC
* Nucleo F103RB
* Nucleo F207ZG
* Nucleo F303RE
* Nucleo F401RE
* Nucleo F767ZI
* Nucleo G071RB
* Nucleo G431RB
* Nucleo H743ZI2
* Nucleo L053R8
* Nucleo L476RG
* P-Nucleo WB55RB

So all supported STM32 series supported by the core were tested except the STM32L1 as I do not have the board at this time.

Thanks in advance
BR