### PR TITLE
Add support for Arduino Nano 33 BLE boards

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1507,7 +1507,11 @@ void Adafruit_NeoPixel::show(void) {
 //    pwm->INTEN |= (PWM_INTEN_SEQEND0_Enabled<<PWM_INTEN_SEQEND0_Pos);
 
     // PSEL must be configured before enabling PWM
+    #ifdef ARDUINO_ARCH_NRF52840
+    pwm->PSEL.OUT[0] = g_APinDescription[pin].name;
+    #else
     pwm->PSEL.OUT[0] = g_ADigitalPinMap[pin];
+    #endif
 
     // Enable the PWM
     pwm->ENABLE = 1;
@@ -1520,7 +1524,7 @@ void Adafruit_NeoPixel::show(void) {
     // But we have to wait for the flag to be set.
     while(!pwm->EVENTS_SEQEND[0])
     {
-      #ifdef ARDUINO_NRF52_ADAFRUIT
+      #ifdef ARDUINO_NRF52_ADAFRUIT || ARDUINO_ARCH_NRF52840
       yield();
       #endif
     }
@@ -1544,6 +1548,7 @@ void Adafruit_NeoPixel::show(void) {
   }// End of DMA implementation
   // ---------------------------------------------------------------------
   else{
+#ifndef ARDUINO_ARCH_NRF52840     
     // Fall back to DWT
     #ifdef ARDUINO_NRF52_ADAFRUIT
       // Bluefruit Feather 52 uses freeRTOS
@@ -1622,6 +1627,7 @@ void Adafruit_NeoPixel::show(void) {
     #elif defined(NRF52_DISABLE_INT)
       __enable_irq();
     #endif
+#endif
   }
 // END of NRF52 implementation
 


### PR DESCRIPTION
Add support for Arduino boards based on [nRF52840](https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52840):

- [Arduino Nano 33 BLE](https://store.arduino.cc/arduino-nano-33-ble)
- [Arduino Nano 33 BLE Sense](https://store.arduino.cc/arduino-nano-33-ble-sense)

Tested with generic WS2812 strip on Arduino Nano 33 BLE and Arduino Nano 33 BLE Sense.