### PR TITLE
Fix build warnings

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1524,7 +1524,7 @@ void Adafruit_NeoPixel::show(void) {
     // But we have to wait for the flag to be set.
     while(!pwm->EVENTS_SEQEND[0])
     {
-      #ifdef ARDUINO_NRF52_ADAFRUIT || ARDUINO_ARCH_NRF52840
+      #if defined(ARDUINO_NRF52_ADAFRUIT) || defined(ARDUINO_ARCH_NRF52840)
       yield();
       #endif
     }

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1415,7 +1415,7 @@ void Adafruit_NeoPixel::show(void) {
 #endif
   };
 
-  for(int device = 0; device < (sizeof(PWM)/sizeof(PWM[0])); device++) {
+  for(unsigned int device = 0; device < (sizeof(PWM)/sizeof(PWM[0])); device++) {
     if( (PWM[device]->ENABLE == 0)                            &&
         (PWM[device]->PSEL.OUT[0] & PWM_PSEL_OUT_CONNECT_Msk) &&
         (PWM[device]->PSEL.OUT[1] & PWM_PSEL_OUT_CONNECT_Msk) &&

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -45,7 +45,7 @@
 
 #include "Adafruit_NeoPixel.h"
 
-#ifdef TARGET_LPC1768
+#if defined(TARGET_LPC1768)
   #include <time.h>
 #endif
 
@@ -87,7 +87,7 @@ Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, uint16_t p, neoPixelType t) :
            type).
 */
 Adafruit_NeoPixel::Adafruit_NeoPixel() :
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
   is800KHz(true),
 #endif
   begun(false), numLEDs(0), numBytes(0), pin(-1), brightness(0), pixels(NULL),
@@ -160,7 +160,7 @@ void Adafruit_NeoPixel::updateType(neoPixelType t) {
   rOffset = (t >> 4) & 0b11; // regarding R/G/B/W offsets
   gOffset = (t >> 2) & 0b11;
   bOffset =  t       & 0b11;
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
   is800KHz = (t < 256);      // 400 KHz flag is 1<<8
 #endif
 
@@ -222,7 +222,7 @@ void Adafruit_NeoPixel::show(void) {
   noInterrupts(); // Need 100% focus on instruction timing
 #endif
 
-#ifdef __AVR__
+#if defined(__AVR__)
 // AVR MCUs -- ATmega & ATtiny (no XMEGA) ---------------------------------
 
   volatile uint16_t
@@ -250,7 +250,7 @@ void Adafruit_NeoPixel::show(void) {
 // 8 MHz(ish) AVR ---------------------------------------------------------
 #if (F_CPU >= 7400000UL) && (F_CPU <= 9500000UL)
 
-#ifdef NEO_KHZ400 // 800 KHz check needed only if 400 KHz support enabled
+#if defined(NEO_KHZ400) // 800 KHz check needed only if 400 KHz support enabled
   if(is800KHz) {
 #endif
 
@@ -637,7 +637,7 @@ void Adafruit_NeoPixel::show(void) {
  #endif // defined(PORTD/B/C)
 #endif // defined(PORTF)
 
-#ifdef NEO_KHZ400
+#if definedNEO_KHZ400)
   } else { // end 800 KHz, do 400 KHz
 
     // Timing is more relaxed; unrolling the inner loop for each bit is
@@ -693,7 +693,7 @@ void Adafruit_NeoPixel::show(void) {
 // 12 MHz(ish) AVR --------------------------------------------------------
 #elif (F_CPU >= 11100000UL) && (F_CPU <= 14300000UL)
 
-#ifdef NEO_KHZ400 // 800 KHz check needed only if 400 KHz support enabled
+#if defined(NEO_KHZ400) // 800 KHz check needed only if 400 KHz support enabled
   if(is800KHz) {
 #endif
 
@@ -958,7 +958,7 @@ void Adafruit_NeoPixel::show(void) {
  #endif // defined(PORTD/B/C)
 #endif // defined(PORTF)
 
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
   } else { // 400 KHz
 
     // 30 instruction clocks per bit: HHHHHHxxxxxxxxxLLLLLLLLLLLLLLL
@@ -1011,7 +1011,7 @@ void Adafruit_NeoPixel::show(void) {
 // 16 MHz(ish) AVR --------------------------------------------------------
 #elif (F_CPU >= 15400000UL) && (F_CPU <= 19000000L)
 
-#ifdef NEO_KHZ400 // 800 KHz check needed only if 400 KHz support enabled
+#if defined(NEO_KHZ400) // 800 KHz check needed only if 400 KHz support enabled
   if(is800KHz) {
 #endif
 
@@ -1060,7 +1060,7 @@ void Adafruit_NeoPixel::show(void) {
         [hi]     "r" (hi),
         [lo]     "r" (lo));
 
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
   } else { // 400 KHz
 
     // The 400 KHz clock on 16 MHz MCU is the most 'relaxed' version.
@@ -1148,7 +1148,7 @@ void Adafruit_NeoPixel::show(void) {
   ARM_DEMCR    |= ARM_DEMCR_TRCENA;
   ARM_DWT_CTRL |= ARM_DWT_CTRL_CYCCNTENA;
 
-#ifdef NEO_KHZ400 // 800 KHz check needed only if 400 KHz support enabled
+#if defined(NEO_KHZ400) // 800 KHz check needed only if 400 KHz support enabled
   if(is800KHz) {
 #endif
     cyc = ARM_DWT_CYCCNT + CYCLES_800;
@@ -1167,7 +1167,7 @@ void Adafruit_NeoPixel::show(void) {
       }
     }
     while(ARM_DWT_CYCCNT - cyc < CYCLES_800);
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
   } else { // 400 kHz bitstream
     cyc = ARM_DWT_CYCCNT + CYCLES_400;
     while(p < end) {
@@ -1206,7 +1206,7 @@ void Adafruit_NeoPixel::show(void) {
   ARM_DEMCR    |= ARM_DEMCR_TRCENA;
   ARM_DWT_CTRL |= ARM_DWT_CTRL_CYCCNTENA;
 
-#ifdef NEO_KHZ400 // 800 KHz check needed only if 400 KHz support enabled
+#if defined(NEO_KHZ400) // 800 KHz check needed only if 400 KHz support enabled
   if(is800KHz) {
 #endif
     cyc = ARM_DWT_CYCCNT + CYCLES_800;
@@ -1225,7 +1225,7 @@ void Adafruit_NeoPixel::show(void) {
       }
     }
     while(ARM_DWT_CYCCNT - cyc < CYCLES_800);
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
   } else { // 400 kHz bitstream
     cyc = ARM_DWT_CYCCNT + CYCLES_400;
     while(p < end) {
@@ -1410,7 +1410,7 @@ void Adafruit_NeoPixel::show(void) {
   // and has no connected pins
   NRF_PWM_Type* PWM[] = {
     NRF_PWM0, NRF_PWM1, NRF_PWM2
-#ifdef NRF_PWM3
+#if defined(NRF_PWM3)
     ,NRF_PWM3
 #endif
   };
@@ -1429,7 +1429,7 @@ void Adafruit_NeoPixel::show(void) {
 
   // only malloc if there is PWM device available
   if ( pwm != NULL ) {
-    #ifdef ARDUINO_NRF52_ADAFRUIT // use thread-safe malloc
+    #if defined(ARDUINO_NRF52_ADAFRUIT) // use thread-safe malloc
       pixels_pattern = (uint16_t *) rtos_malloc(pattern_size);
     #else
       pixels_pattern = (uint16_t *) malloc(pattern_size);
@@ -1445,7 +1445,7 @@ void Adafruit_NeoPixel::show(void) {
       uint8_t pix = pixels[n];
 
       for(uint8_t mask=0x80; mask>0; mask >>= 1) {
-        #ifdef NEO_KHZ400
+        #if defined(NEO_KHZ400)
         if( !is800KHz ) {
           pixels_pattern[pos] = (pix & mask) ? MAGIC_T1H_400KHz : MAGIC_T0H_400KHz;
         }else
@@ -1471,7 +1471,7 @@ void Adafruit_NeoPixel::show(void) {
     // Setting of the maximum count
     // but keeping it on 16Mhz allows for more granularity just
     // in case someone wants to do more fine-tuning of the timing.
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
     if( !is800KHz ) {
       pwm->COUNTERTOP = (CTOPVAL_400KHz << PWM_COUNTERTOP_COUNTERTOP_Pos);
     }else
@@ -1507,7 +1507,7 @@ void Adafruit_NeoPixel::show(void) {
 //    pwm->INTEN |= (PWM_INTEN_SEQEND0_Enabled<<PWM_INTEN_SEQEND0_Pos);
 
     // PSEL must be configured before enabling PWM
-    #ifdef ARDUINO_ARCH_NRF52840
+    #if defined(ARDUINO_ARCH_NRF52840)
     pwm->PSEL.OUT[0] = g_APinDescription[pin].name;
     #else
     pwm->PSEL.OUT[0] = g_ADigitalPinMap[pin];
@@ -1540,7 +1540,7 @@ void Adafruit_NeoPixel::show(void) {
 
     pwm->PSEL.OUT[0] = 0xFFFFFFFFUL;
 
-    #ifdef ARDUINO_NRF52_ADAFRUIT  // use thread-safe free
+    #if defined(ARDUINO_NRF52_ADAFRUIT)  // use thread-safe free
       rtos_free(pixels_pattern);
     #else
       free(pixels_pattern);
@@ -1550,7 +1550,7 @@ void Adafruit_NeoPixel::show(void) {
   else{
 #ifndef ARDUINO_ARCH_NRF52840     
     // Fall back to DWT
-    #ifdef ARDUINO_NRF52_ADAFRUIT
+    #if defined(ARDUINO_NRF52_ADAFRUIT)
       // Bluefruit Feather 52 uses freeRTOS
       // Critical Section is used since it does not block SoftDevice execution
       taskENTER_CRITICAL();
@@ -1570,7 +1570,7 @@ void Adafruit_NeoPixel::show(void) {
     uint32_t CYCLES_X00_T1H = CYCLES_800_T1H;
     uint32_t CYCLES_X00_T0H = CYCLES_800_T0H;
 
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
     if( !is800KHz )
     {
       CYCLES_X00     = CYCLES_400;
@@ -1622,7 +1622,7 @@ void Adafruit_NeoPixel::show(void) {
     }
 
     // Enable interrupts again
-    #ifdef ARDUINO_NRF52_ADAFRUIT
+    #if defined(ARDUINO_NRF52_ADAFRUIT)
       taskEXIT_CRITICAL();
     #elif defined(NRF52_DISABLE_INT)
       __enable_irq();
@@ -1648,7 +1648,7 @@ void Adafruit_NeoPixel::show(void) {
   volatile uint32_t *set = &(PORT->Group[portNum].OUTSET.reg),
                     *clr = &(PORT->Group[portNum].OUTCLR.reg);
 
-#ifdef NEO_KHZ400 // 800 KHz check needed only if 400 KHz support enabled
+#if defined(NEO_KHZ400) // 800 KHz check needed only if 400 KHz support enabled
   if(is800KHz) {
 #endif
     for(;;) {
@@ -1673,7 +1673,7 @@ void Adafruit_NeoPixel::show(void) {
         bitMask = 0x80;
       }
     }
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
   } else { // 400 KHz bitstream
     for(;;) {
       *set = pinMask;
@@ -1740,13 +1740,13 @@ void Adafruit_NeoPixel::show(void) {
   uint32_t t0, t1, top, ticks,
            saveLoad = SysTick->LOAD, saveVal = SysTick->VAL;
 
-#ifdef NEO_KHZ400 // 800 KHz check needed only if 400 KHz support enabled
+#if defined(NEO_KHZ400) // 800 KHz check needed only if 400 KHz support enabled
   if(is800KHz) {
 #endif
     top =       (uint32_t)(F_CPU * 0.00000125); // Bit hi + lo = 1.25 uS
     t0  = top - (uint32_t)(F_CPU * 0.00000040); // 0 = 0.4 uS hi
     t1  = top - (uint32_t)(F_CPU * 0.00000080); // 1 = 0.8 uS hi
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
   } else { // 400 KHz bitstream
     top =       (uint32_t)(F_CPU * 0.00000250); // Bit hi + lo = 2.5 uS
     t0  = top - (uint32_t)(F_CPU * 0.00000050); // 0 = 0.5 uS hi
@@ -1791,7 +1791,7 @@ void Adafruit_NeoPixel::show(void) {
   volatile uint16_t *set = &(PIN_MAP[pin].gpio_device->regs->BSRRL);
   volatile uint16_t *clr = &(PIN_MAP[pin].gpio_device->regs->BSRRH);
 
-#ifdef NEO_KHZ400 // 800 KHz check needed only if 400 KHz support enabled
+#if defined(NEO_KHZ400) // 800 KHz check needed only if 400 KHz support enabled
   if(is800KHz) {
 #endif
     for(;;) {
@@ -1850,7 +1850,7 @@ void Adafruit_NeoPixel::show(void) {
         bitMask = 0x80;
       }
     }
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
   } else { // 400 KHz bitstream
     // ToDo!
   }
@@ -1863,7 +1863,7 @@ void Adafruit_NeoPixel::show(void) {
   p       = *ptr++;
   bitMask =  0x80;
 
-#ifdef NEO_KHZ400 // 800 KHz check needed only if 400 KHz support enabled
+#if defined(NEO_KHZ400) // 800 KHz check needed only if 400 KHz support enabled
   if(is800KHz) {
 #endif
     for(;;) {
@@ -1894,7 +1894,7 @@ void Adafruit_NeoPixel::show(void) {
         bitMask = 0x80;
       }
     }
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
   } else { // 400 KHz bitstream
     // ToDo!
   }
@@ -1904,7 +1904,7 @@ void Adafruit_NeoPixel::show(void) {
                     pix = *p++, mask = 0x80;
   uint32_t          cyc;
   uint32_t saveLoad = SysTick->LOAD, saveVal = SysTick->VAL;
-#ifdef NEO_KHZ400 // 800 KHz check needed only if 400 KHz support enabled
+#if defined(NEO_KHZ400) // 800 KHz check needed only if 400 KHz support enabled
   if(is800KHz) {
 #endif
     uint32_t top = (F_CPU /  800000);       // 1.25µs
@@ -1924,7 +1924,7 @@ void Adafruit_NeoPixel::show(void) {
       }
       while(SysTick->VAL <= cyc);
     }
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
   } else { // 400 kHz bitstream
     uint32_t top = (F_CPU /  400000);       // 2.5µs
     uint32_t t0  = top - (F_CPU / 2000000); // 0.5µs
@@ -2060,13 +2060,13 @@ void Adafruit_NeoPixel::show(void) {
   pix       = *p++;
   mask      = 0x80;
 
-#ifdef NEO_KHZ400 // 800 KHz check needed only if 400 KHz support enabled
+#if defined(NEO_KHZ400) // 800 KHz check needed only if 400 KHz support enabled
   if(is800KHz) {
 #endif
     time0  = TIME_800_0;
     time1  = TIME_800_1;
     period = PERIOD_800;
-#ifdef NEO_KHZ400
+#if defined(NEO_KHZ400)
   } else { // 400 KHz bitstream
     time0  = TIME_400_0;
     time1  = TIME_400_1;
@@ -2222,7 +2222,7 @@ void Adafruit_NeoPixel::setPin(uint16_t p) {
     pinMode(p, OUTPUT);
     digitalWrite(p, LOW);
   }
-#ifdef __AVR__
+#if defined(__AVR__)
   port    = portOutputRegister(digitalPinToPort(p));
   pinMask = digitalPinToBitMask(p);
 #endif


### PR DESCRIPTION
**Sscope of change**

* Commit 141f6c8 changes multiple `#ifdef X` statements that are not otherwise erroneous to use the style `#if defined(X)`
* The fix at line 1527 (commit 2a6ebf5) is a clear example of why `#ifdef X` is not preferred … specifically because it can cause inadvertent errors, such as is fixed by this single-line commit.
* The fix at line 1418 (commit b8c45cb) is a trivial fix to a compiler warning.

**Known limitations**
There does not appear to be an automated build process for all the variations of code that could be `#define`'d.  Thus, manual code review (and automated build, if available) would be both appreciated and recommended, if only to verify no missed parenthesis, compiler complaints, or the like.
