### PR TITLE
Replace deprecated boolean with bool

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -154,7 +154,7 @@ void Adafruit_NeoPixel::updateLength(uint16_t n) {
            (length, pin, type).
 */
 void Adafruit_NeoPixel::updateType(neoPixelType t) {
-  boolean oldThreeBytesPerPixel = (wOffset == rOffset); // false if RGBW
+  bool oldThreeBytesPerPixel = (wOffset == rOffset); // false if RGBW
 
   wOffset = (t >> 6) & 0b11; // See notes in header file
   rOffset = (t >> 4) & 0b11; // regarding R/G/B/W offsets
@@ -167,7 +167,7 @@ void Adafruit_NeoPixel::updateType(neoPixelType t) {
   // If bytes-per-pixel has changed (and pixel data was previously
   // allocated), re-allocate to new size. Will clear any data.
   if(pixels) {
-    boolean newThreeBytesPerPixel = (wOffset == rOffset);
+    bool newThreeBytesPerPixel = (wOffset == rOffset);
     if(newThreeBytesPerPixel != oldThreeBytesPerPixel) updateLength(numLEDs);
   }
 }

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -335,9 +335,9 @@ class Adafruit_NeoPixel {
  protected:
 
 #ifdef NEO_KHZ400  // If 400 KHz NeoPixel support enabled...
-  bool           is800KHz;   ///< true if 800 KHz pixels
+  bool              is800KHz;   ///< true if 800 KHz pixels
 #endif
-  bool           begun;      ///< true if begin() previously called
+  bool              begun;      ///< true if begin() previously called
   uint16_t          numLEDs;    ///< Number of RGB LEDs in strip
   uint16_t          numBytes;   ///< Size of 'pixels' buffer below
   int16_t           pin;        ///< Output pin number (-1 if not yet set)

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -231,7 +231,7 @@ class Adafruit_NeoPixel {
     @return  1 or true if show() will start sending immediately, 0 or false
              if show() would block (meaning some idle time is available).
   */
-  boolean           canShow(void) const { return (micros()-endTime) >= 300L; }
+  bool           canShow(void) const { return (micros()-endTime) >= 300L; }
   /*!
     @brief   Get a pointer directly to the NeoPixel data buffer in RAM.
              Pixel data is stored in a device-native format (a la the NEO_*
@@ -335,9 +335,9 @@ class Adafruit_NeoPixel {
  protected:
 
 #ifdef NEO_KHZ400  // If 400 KHz NeoPixel support enabled...
-  boolean           is800KHz;   ///< true if 800 KHz pixels
+  bool           is800KHz;   ///< true if 800 KHz pixels
 #endif
-  boolean           begun;      ///< true if begin() previously called
+  bool           begun;      ///< true if begin() previously called
   uint16_t          numLEDs;    ///< Number of RGB LEDs in strip
   uint16_t          numBytes;   ///< Size of 'pixels' buffer below
   int16_t           pin;        ///< Output pin number (-1 if not yet set)


### PR DESCRIPTION
Correct type should be bool since boolean is deprecated and give a lot of warnings during build.
This PR fixes it.
No other changes.