### PR TITLE
Fix Nano 33 BLE support

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -1416,8 +1416,7 @@ void Adafruit_NeoPixel::show(void) {
   };
 
   for(unsigned int device = 0; device < (sizeof(PWM)/sizeof(PWM[0])); device++) {
-    if( (PWM[device]->ENABLE == 0)                            &&
-        (PWM[device]->PSEL.OUT[0] & PWM_PSEL_OUT_CONNECT_Msk) &&
+    if( (PWM[device]->PSEL.OUT[0] & PWM_PSEL_OUT_CONNECT_Msk) &&
         (PWM[device]->PSEL.OUT[1] & PWM_PSEL_OUT_CONNECT_Msk) &&
         (PWM[device]->PSEL.OUT[2] & PWM_PSEL_OUT_CONNECT_Msk) &&
         (PWM[device]->PSEL.OUT[3] & PWM_PSEL_OUT_CONNECT_Msk)


### PR DESCRIPTION
Hi --

I was having issues where there would be no output to the LED strip on my Nano 33 BLE Sense board. After some debugging, I found out this line was the issue. `ENABLE` seems to always be equal to 1. Removing this line fixed it and the library seems to work fine - I haven't noticed any adverse effects.

cc/ @manchoz - since you authored the original PR to add support, perhaps you can shed some light on whether this is a proper fix?