### PR TITLE
Support for GPIO16/D0

### DIFF
--- a/esp8266.c
+++ b/esp8266.c
@@ -24,6 +24,14 @@ void espShow(
  uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
 #endif
 
+#ifdef ESP8266
+// compensation for if (pin == ...)
+// high 400-410ns low 800-810ns period 1300ns 769kHz
+#define COMP_CYCLES     3
+#else
+#define COMP_CYCLES     0
+#endif
+
 #define CYCLES_800_T0H  (F_CPU / 2500000) // 0.4us
 #define CYCLES_800_T1H  (F_CPU / 1250000) // 0.8us
 #define CYCLES_800      (F_CPU /  800000) // 1.25us per bit
@@ -44,14 +52,24 @@ void espShow(
 #ifdef NEO_KHZ400
   if(is800KHz) {
 #endif
-    time0  = CYCLES_800_T0H;
-    time1  = CYCLES_800_T1H;
+    time0  = CYCLES_800_T0H - COMP_CYCLES;
+    time1  = CYCLES_800_T1H - COMP_CYCLES;
     period = CYCLES_800;
 #ifdef NEO_KHZ400
   } else { // 400 KHz bitstream
-    time0  = CYCLES_400_T0H;
-    time1  = CYCLES_400_T1H;
+    time0  = CYCLES_400_T0H - COMP_CYCLES;
+    time1  = CYCLES_400_T1H - COMP_CYCLES;
     period = CYCLES_400;
+  }
+#endif
+
+#ifdef ESP8266
+  uint32_t gpio_clear = 0;
+  uint32_t gpio_set = 0;
+  if (pin == 16) {
+    // reading and writing RTC_GPIO_OUT is too slow inside the loop
+    gpio_clear = (READ_PERI_REG(RTC_GPIO_OUT) & (uint32)0xfffffffe);
+    gpio_set = gpio_clear | 1;
   }
 #endif
 
@@ -59,14 +77,22 @@ void espShow(
     if(pix & mask) t = time1;                             // Bit high duration
     while(((c = _getCycleCount()) - startTime) < period); // Wait for bit start
 #ifdef ESP8266
-    GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinMask);       // Set high
+    if (pin == 16) {
+      WRITE_PERI_REG(RTC_GPIO_OUT, gpio_set);
+    } else {
+      GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinMask); // Set high
+    }
 #else
     gpio_set_level(pin, HIGH);
 #endif
     startTime = c;                                        // Save start time
     while(((c = _getCycleCount()) - startTime) < t);      // Wait high duration
 #ifdef ESP8266
-    GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinMask);       // Set low
+    if (pin == 16) {
+      WRITE_PERI_REG(RTC_GPIO_OUT, gpio_clear);
+    } else {
+      GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinMask); // Set low
+    }
 #else
     gpio_set_level(pin, LOW);
 #endif


### PR DESCRIPTION
Adds support for GPIO16/D0 for ESP8266 by using the RTC register address instead the GPIO register address.

The changes can be tested with any example code.

I tested it with an 8 pixel strip (WS2812 800kHz, CPU 80MHz) and measured timings with an oscilloscope. The timings match the timings without modifications and are within the datasheets specifications.
Ports tested 12/D7 and 16/D0.

ESP32 code isn't affected.