### PR TITLE
Update RGBWstrandtest.ino

### DIFF
--- a/examples/RGBWstrandtest/RGBWstrandtest.ino
+++ b/examples/RGBWstrandtest/RGBWstrandtest.ino
@@ -14,7 +14,7 @@
 #define LED_COUNT  60
 
 // NeoPixel brightness, 0 (min) to 255 (max)
-#define BRIGHTNESS 50
+#define BRIGHTNESS 50 // Set BRIGHTNESS to about 1/5 (max = 255)
 
 // Declare our NeoPixel strip object:
 Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRBW + NEO_KHZ800);
@@ -37,7 +37,7 @@ void setup() {
 
   strip.begin();           // INITIALIZE NeoPixel strip object (REQUIRED)
   strip.show();            // Turn OFF all pixels ASAP
-  strip.setBrightness(50); // Set BRIGHTNESS to about 1/5 (max = 255)
+  strip.setBrightness(BRIGHTNESS);
 }
 
 void loop() {


### PR DESCRIPTION
The defintion of BRIGHTNESS wasn't used in the setup-routine, therefore changing its value didn't change the brightness as expected