### PR TITLE
Update for Arduino RP2040 support release

### DIFF
--- a/rp2040.c
+++ b/rp2040.c
@@ -9,9 +9,7 @@
 
 #if defined(ARDUINO_ARCH_RP2040)
 
-#include <stdio.h>
 #include <stdlib.h>
-#include "pico/stdlib.h"
 #include "hardware/pio.h"
 #include "hardware/clocks.h"
 


### PR DESCRIPTION
RP2040 support now works with the newly released **Arduino Mbed OS RP2040 Boards** package as well as Earle Philhower's unoficial RP2040 board package.
