### PR TITLE
Fix ESP32-S2 reserving too many channels

### DIFF
--- a/esp.c
+++ b/esp.c
@@ -89,6 +89,7 @@ void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) 
         if (!rmt_reserved_channels[i]) {
             rmt_reserved_channels[i] = true;
             channel = i;
+            break;
         }
     }
     if (channel == ADAFRUIT_RMT_CHANNEL_MAX) {


### PR DESCRIPTION
Fixes a missing `break` that causes the ESP32-S2 to always reserve all channels allocated to it, which might prevent multiple Neopixel lines from running in some high-performance cases. Thanks to @krupis for pointing this out in #271
