### PR TITLE
Fix Arduino Nano33BLE with core >= 2.0.0

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -57,6 +57,14 @@
 //#define NRF52_DISABLE_INT
 #endif
 
+#if defined(ARDUINO_ARCH_NRF52840)
+#if defined __has_include
+#  if __has_include (<pinDefinitions.h>)
+#    include <pinDefinitions.h>
+#  endif
+#endif
+#endif
+
 /*!
   @brief   NeoPixel constructor when length, pin and pixel type are known
            at compile-time.


### PR DESCRIPTION
Latest mbed-based cores hide the porting layer to greatuly speedup compilation.
In case direct access to such structures is needed, pinDefinitions.h must be included.

By checking the file presence via __has_include we also keep compatibility with previous version of the core

Fixes https://github.com/arduino/ArduinoCore-mbed/issues/241