### PR TITLE
Fix possible rounding issue when using ESP8266 @ 160MHz

### DIFF
--- a/esp8266.c
+++ b/esp8266.c
@@ -24,9 +24,9 @@ void espShow(
  uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
 #endif
 
-#define CYCLES_800_T0H  (F_CPU / 2500000) // 0.4us
-#define CYCLES_800_T1H  (F_CPU / 1250000) // 0.8us
-#define CYCLES_800      (F_CPU /  800000) // 1.25us per bit
+#define CYCLES_800_T0H  (F_CPU / 2500001) // 0.4us
+#define CYCLES_800_T1H  (F_CPU / 1250001) // 0.8us
+#define CYCLES_800      (F_CPU /  800001) // 1.25us per bit
 #define CYCLES_400_T0H  (F_CPU / 2000000) // 0.5uS
 #define CYCLES_400_T1H  (F_CPU /  833333) // 1.2us
 #define CYCLES_400      (F_CPU /  400000) // 2.5us per bit


### PR DESCRIPTION
Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- the change does allow using wemos d1 mini to run @ 160 MHz and drive ws2812b

- I do not know if that affects any other boards/platforms

- I've tested one firmware version with the code in the pull request and in comparison the original code
- https://youtu.be/9iwp4lMFI8g
- Board: "LOLIN(WEMOS) D1 R2 & mini"
- CPU Frequency: "160 MHz" and "80 MHz"
- All other parameters are left to their default values.

Issue ref: https://github.com/adafruit/Adafruit_NeoPixel/issues/280
