### PR TITLE
Fix build with older ESP-IDF versions

### DIFF
--- a/esp.c
+++ b/esp.c
@@ -22,6 +22,12 @@
 #include <Arduino.h>
 #include "driver/rmt.h"
 
+#if defined(ESP_IDF_VERSION)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+#define HAS_ESP_IDF_4
+#endif
+#endif
+
 // This code is adapted from the ESP-IDF v3.4 RMT "led_strip" example, altered
 // to work with the Arduino version of the ESP-IDF (3.2)
 
@@ -97,7 +103,7 @@ void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) 
         return;
     }
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+#if defined(HAS_ESP_IDF_4)
     rmt_config_t config = RMT_DEFAULT_CONFIG_TX(pin, channel);
     config.clk_div = 2;
 #else
@@ -125,7 +131,7 @@ void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) 
     // Convert NS timings to ticks
     uint32_t counter_clk_hz = 0;
 
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+#if defined(HAS_ESP_IDF_4)
     rmt_get_counter_clock(channel, &counter_clk_hz);
 #else
     // this emulates the rmt_get_counter_clock() function from ESP-IDF 3.4


### PR DESCRIPTION
This PR fixes the build errors with ESP-IDF versions before v4.x that come with arduino-esp32 versions before v2.x.
The errors were caused by `ESP_IDF_VERSION` and `ESP_IDF_VERSION_VAL` not being available in ESP-IDF v3.x.

I'm not sure how I missed this obvious oversight in my previous PR, but I this should fix it.

I tested this one with the following boards and arduino-esp32 versions.

- ESP32-DevKitS + external WS2812 (arduino-esp32 v1.0.4-1.0.6 and v2.0.0)
- ESP32-S2-Saola-1 + on-board WS2812 (only supported since arduino-esp32 v2.0.0)
- ESP32-C3-DevKitC-02 + on-board WS2812 (only supported since arduino-esp32 v2.0.0)
