### PR TITLE
Update RP2040 code to find a free PIO state machine

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit NeoPixel
-version=1.10.1
+version=1.10.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for controlling single-wire-based LED pixels and strip.

--- a/rp2040.c
+++ b/rp2040.c
@@ -17,9 +17,16 @@
 
 void rp2040Init(uint8_t pin, bool is800KHz)
 {
-    // todo get free sm
+    // Find a free SM on one of the PIO's
     PIO pio = pio0;
     int sm = 0;
+    pio_sm = pio_claim_unused_sm(pio, false); // don't panic
+    // Try pio1 if SM not found
+    if (sm < 0) {
+      pio = pio1;
+      sm = pio_claim_unused_sm(pio, true); // panic if no SM is free
+    }
+
     uint offset = pio_add_program(pio, &ws2812_program);
 
     if (is800KHz)

--- a/rp2040.c
+++ b/rp2040.c
@@ -57,4 +57,4 @@ void  rp2040Show(uint8_t pin, uint8_t *pixels, uint32_t numBytes, bool is800KHz)
         pio_sm_put_blocking(pio0, 0, ((uint32_t)*pixels++)<< 24);
 }
 
-#endif // KENDRYTE_K210
+#endif // RP2040

--- a/rp2040.c
+++ b/rp2040.c
@@ -20,7 +20,7 @@ void rp2040Init(uint8_t pin, bool is800KHz)
     // Find a free SM on one of the PIO's
     PIO pio = pio0;
     int sm = 0;
-    pio_sm = pio_claim_unused_sm(pio, false); // don't panic
+    sm = pio_claim_unused_sm(pio, false); // don't panic
     // Try pio1 if SM not found
     if (sm < 0) {
       pio = pio1;


### PR DESCRIPTION
The original RP2040 PIO and state machine choice was hard coded into the library. This change will search for and use a free PIO state machine.

Typo also fixed and version incremented.