### PR TITLE
Add support for SAMD11C14

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -2253,10 +2253,11 @@ void Adafruit_NeoPixel::show(void) {
   }
   // END of NRF52 implementation
 
-#elif defined(__SAMD21E17A__) || defined(__SAMD21G18A__) ||                    \
-    defined(__SAMD21E18A__) ||                                                 \
-    defined(__SAMD21J18A__) // Arduino Zero, Gemma/Trinket M0, SODAQ Autonomo
-                            // and others
+#elif defined(__SAMD21E17A__) || defined(__SAMD21G18A__) || \
+      defined(__SAMD21E18A__) || defined(__SAMD21J18A__) || \
+      defined (__SAMD11C14A__)
+  // Arduino Zero, Gemma/Trinket M0, SODAQ Autonomo
+  // and others
   // Tried this with a timer/counter, couldn't quite get adequate
   // resolution. So yay, you get a load of goofball NOPs...
 


### PR DESCRIPTION
This change just adds a check for the SAMD11C14 microcontroller, which uses the same code section as its siblings to write to the pixels. 

I have tested with an ATSAMD11C14 running on a custom PCB with RGBW NeoPixels. I'm using MattairTech's generic ATSAMD11C14 core and PA04 (pin 4) as the LED data pin.

Please let me know if there are any other things I need to address. Without this change, the ATSAMD11 doesn't have any code in the `show` function, so the LEDs do nothing.

Resolves https://github.com/adafruit/Adafruit_NeoPixel/issues/157


