### PR TITLE
Define default #include directives in library metadata

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Arduino library for controlling single-wire-based LED pixels and strip
 category=Display
 url=https://github.com/adafruit/Adafruit_NeoPixel
 architectures=*
+includes=Adafruit_NeoPixel.h


### PR DESCRIPTION
When a library is selected from the **Sketch > Include Library** menu of the Arduino IDE, `#include` directives for its header files are added to the sketch.

By default, `#include` directives for all header files present in the library's root source folder are added. In some cases that is not wanted. For this reason, the Arduino IDE allows the customization of the behavior of this IDE feature via the `includes` field of the `library.properties` library metadata file. When this field is defined, the IDE will instead add `#include` directives for only the files in this comma-separated list:

https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format

"**Adafruit NeoPixel**" is a library where the default behavior of the Arduino IDE is not appropriate. The reason is the presence of [the `rp2040_pio.h` header](https://github.com/adafruit/Adafruit_NeoPixel/blob/master/rp2040_pio.h) in the root source folder. This file contains code specific to the RP2040, and so adding an `#include` directive for it will result in a compilation error when a board of any other architecture is selected:

https://forum.arduino.cc/t/hardware-pio-h-error/992695

Since the primary `Adafruit_NeoPixel.h` header contains a conditional `#include` for that file, there is never a need for the user to have an `#include` directive for the file added to their sketch along with the one for `Adafruit_NeoPixel.h`. Correct behavior of the Arduino IDE's "**Include Library**" feature will be ensured by specifying `Adafruit_NeoPixel.h` in the `includes` field of `library.properties`.