### PR TITLE
added setPixelColor(uint16_t n, uint32_t c, uint8_t brt) function

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -3153,6 +3153,38 @@ void Adafruit_NeoPixel::setPixelColor(uint16_t n, uint32_t c) {
 }
 
 /*!
+  @brief   Set a pixel's color using a 32-bit 'packed' RGB or RGBW value. Sets
+           the color brightness directly, ignoring the global strip brightness.
+  @param   n  Pixel index, starting from 0.
+  @param   c  32-bit color value. Most significant byte is white (for RGBW
+              pixels) or ignored (for RGB pixels), next is red, then green,
+              and least significant byte is blue.
+  @param   brt  Brightness setting, 0=minimum (off), 255=brightest.
+*/
+void Adafruit_NeoPixel::setPixelColor(uint16_t n, uint32_t c, uint8_t brt) {
+  if (n < numLEDs) {
+    uint8_t *p, r = (uint8_t)(c >> 16), g = (uint8_t)(c >> 8), b = (uint8_t)c;
+
+    uint8_t newBrightness = brt + 1; // See notes in setBrightness()
+    if (newBrightness) { 
+      r = (r * newBrightness) >> 8;
+      g = (g * newBrightness) >> 8;
+      b = (b * newBrightness) >> 8;
+    }
+    if (wOffset == rOffset) {
+      p = &pixels[n * 3];
+    } else {
+      p = &pixels[n * 4];
+      uint8_t w = (uint8_t)(c >> 24);
+      p[wOffset] = newBrightness ? ((w * newBrightness) >> 8) : w;
+    }
+    p[rOffset] = r;
+    p[gOffset] = g;
+    p[bOffset] = b;
+  }
+}
+
+/*!
   @brief   Fill all or part of the NeoPixel strip with a color.
   @param   c      32-bit color value. Most significant byte is white (for
                   RGBW pixels) or ignored (for RGB pixels), next is red,

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -227,6 +227,7 @@ public:
   void setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b);
   void setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t w);
   void setPixelColor(uint16_t n, uint32_t c);
+  void setPixelColor(uint16_t n, uint32_t c, uint8_t brt);
   void fill(uint32_t c = 0, uint16_t first = 0, uint16_t count = 0);
   void setBrightness(uint8_t);
   void clear(void);

--- a/examples/StrandtestBLE_nodelay/StrandtestBLE_nodelay.ino
+++ b/examples/StrandtestBLE_nodelay/StrandtestBLE_nodelay.ino
@@ -142,7 +142,7 @@ void theaterChase(uint32_t color, int wait) {
     strip.setPixelColor(i + pixelQueue, color); //  Set pixel's color (in RAM)
   }
   strip.show();                             //  Update strip to match
-  for(int i=0; i < pixelNumber; i+3) {
+  for(int i=0; i < pixelNumber; i+=3) {
     strip.setPixelColor(i + pixelQueue, strip.Color(0, 0, 0)); //  Set pixel's color (in RAM)
   }
   pixelQueue++;                             //  Advance current pixel
@@ -167,11 +167,11 @@ void rainbow(uint8_t wait) {
 void theaterChaseRainbow(uint8_t wait) {
   if(pixelInterval != wait)
     pixelInterval = wait;                   //  Update delay time  
-  for(int i=0; i < pixelNumber; i+3) {
+  for(int i=0; i < pixelNumber; i+=3) {
     strip.setPixelColor(i + pixelQueue, Wheel((i + pixelCycle) % 255)); //  Update delay time  
   }
   strip.show();
-  for(int i=0; i < pixelNumber; i+3) {
+  for(int i=0; i < pixelNumber; i+=3) {
     strip.setPixelColor(i + pixelQueue, strip.Color(0, 0, 0)); //  Update delay time  
   }      
   pixelQueue++;                           //  Advance current queue  

--- a/examples/strandtest_nodelay/strandtest_nodelay.ino
+++ b/examples/strandtest_nodelay/strandtest_nodelay.ino
@@ -125,7 +125,7 @@ void theaterChase(uint32_t color, int wait) {
     strip.setPixelColor(i + pixelQueue, color); //  Set pixel's color (in RAM)
   }
   strip.show();                             //  Update strip to match
-  for(int i=0; i < pixelNumber; i+3) {
+  for(int i=0; i < pixelNumber; i+=3) {
     strip.setPixelColor(i + pixelQueue, strip.Color(0, 0, 0)); //  Set pixel's color (in RAM)
   }
   pixelQueue++;                             //  Advance current pixel
@@ -150,11 +150,11 @@ void rainbow(uint8_t wait) {
 void theaterChaseRainbow(uint8_t wait) {
   if(pixelInterval != wait)
     pixelInterval = wait;                   //  Update delay time  
-  for(int i=0; i < pixelNumber; i+3) {
+  for(int i=0; i < pixelNumber; i+=3) {
     strip.setPixelColor(i + pixelQueue, Wheel((i + pixelCycle) % 255)); //  Update delay time  
   }
   strip.show();
-  for(int i=0; i < pixelNumber; i+3) {
+  for(int i=0; i < pixelNumber; i+=3) {
     strip.setPixelColor(i + pixelQueue, strip.Color(0, 0, 0)); //  Update delay time  
   }      
   pixelQueue++;                           //  Advance current queue  


### PR DESCRIPTION
I've created a project which is more focused on individual LED brightness, rather than color, so this new setPixelColor() function makes manipulating the LEDs a bit easier. It sets an LED's brightness directly, and ignores the global strip brightness.

Since it's a new function, I don't think it should break any existing code. Here is my test code, which fades a strip of LEDs in and out:
```c++
#include <Adafruit_NeoPixel.h>

#define PIN      12
#define NUMPIXELS 8

Adafruit_NeoPixel pixels(NUMPIXELS, PIN, NEO_GRB + NEO_KHZ800);

uint8_t brightness = 0;
int8_t dir = 1;

void setup() {
  pixels.begin();
}

void loop() {
  for(int i=0; i<NUMPIXELS; i++) { // fill strip with BLUE at a given brightness
    pixels.setPixelColor(i, 0x0000ff, brightness);
  }
  brightness += dir; // increase or decrease brightness for each loop

  if(brightness == 0 || brightness == 255) { // change fade direction
    dir *= -1;
  }

  pixels.show();
  delay(10);
}
```

Note, the existing setPixelColor(uint16_t n, uint32_t c) could be optimized to this:
```c++
void Adafruit_NeoPixel::setPixelColor(uint16_t n, uint32_t c) {
  Adafruit_NeoPixel::setPixelColor(n, c, brightness - 1);
}
```
But I did not do that in case you prefer readability over optimization.


