### PR TITLE
Fixed: arduino-esp32 2.0.5 calling abort() from espShow()

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -283,7 +283,8 @@ void Adafruit_NeoPixel::show(void) {
     // to the PORT register as needed.
 
     // NRF52 may use PWM + DMA (if available), may not need to disable interrupt
-#if !(defined(NRF52) || defined(NRF52_SERIES))
+    // ESP32 may not disable interrupts because espShow() uses RMT which tries to acquire locks
+#if !(defined(NRF52) || defined(NRF52_SERIES) || defined(ESP32))
   noInterrupts(); // Need 100% focus on instruction timing
 #endif
 
@@ -3031,7 +3032,7 @@ if(is800KHz) {
 
   // END ARCHITECTURE SELECT ------------------------------------------------
 
-#if !(defined(NRF52) || defined(NRF52_SERIES))
+#if !(defined(NRF52) || defined(NRF52_SERIES) || defined(ESP32))
   interrupts();
 #endif
 

--- a/examples/strandtest_nodelay/strandtest_nodelay.ino
+++ b/examples/strandtest_nodelay/strandtest_nodelay.ino
@@ -17,7 +17,12 @@
 
 // Which pin on the Arduino is connected to the NeoPixels?
 // On a Trinket or Gemma we suggest changing this to 1:
+#ifdef ESP32
+// Cannot use 6 as output for ESP. Pins 6-11 are connected to SPI flash. Use 16 instead.
+#define LED_PIN    16
+#else
 #define LED_PIN    6
+#endif
 
 // How many NeoPixels are attached to the Arduino?
 #define LED_COUNT 60
@@ -125,7 +130,7 @@ void theaterChase(uint32_t color, int wait) {
     strip.setPixelColor(i + pixelQueue, color); //  Set pixel's color (in RAM)
   }
   strip.show();                             //  Update strip to match
-  for(int i=0; i < pixelNumber; i+3) {
+  for(int i=0; i < pixelNumber; i+=3) {
     strip.setPixelColor(i + pixelQueue, strip.Color(0, 0, 0)); //  Set pixel's color (in RAM)
   }
   pixelQueue++;                             //  Advance current pixel
@@ -150,11 +155,11 @@ void rainbow(uint8_t wait) {
 void theaterChaseRainbow(uint8_t wait) {
   if(pixelInterval != wait)
     pixelInterval = wait;                   //  Update delay time  
-  for(int i=0; i < pixelNumber; i+3) {
+  for(int i=0; i < pixelNumber; i+=3) {
     strip.setPixelColor(i + pixelQueue, Wheel((i + pixelCycle) % 255)); //  Update delay time  
   }
   strip.show();
-  for(int i=0; i < pixelNumber; i+3) {
+  for(int i=0; i < pixelNumber; i+=3) {
     strip.setPixelColor(i + pixelQueue, strip.Color(0, 0, 0)); //  Update delay time  
   }      
   pixelQueue++;                           //  Advance current queue  


### PR DESCRIPTION
- Disabled calls to noInterrupt()/interrupt() in espShow() on ESP32. espShow() calls rmt_driver_install() which tries to acquire a mutex. Recursive mutexes are not allowed inside an interrupt context so lock_acquire_generic() calls abort().

- Change only applies to ESP32 platforms and the calls to noInterrupt()/interrupt() are not needed as RMT will handle all the bit twiddling. 