### PR TITLE
esp8266: remove unused if checks

### DIFF
--- a/esp8266.c
+++ b/esp8266.c
@@ -5,9 +5,7 @@
 #if defined(ESP8266)
 
 #include <Arduino.h>
-#ifdef ESP8266
 #include <eagle_soc.h>
-#endif
 
 static uint32_t _getCycleCount(void) __attribute__((always_inline));
 static inline uint32_t _getCycleCount(void) {
@@ -16,13 +14,8 @@ static inline uint32_t _getCycleCount(void) {
   return ccount;
 }
 
-#ifdef ESP8266
 IRAM_ATTR void espShow(
  uint8_t pin, uint8_t *pixels, uint32_t numBytes, __attribute__((unused)) boolean is800KHz) {
-#else
-void espShow(
- uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
-#endif
 
 #define CYCLES_800_T0H  (F_CPU / 2500001) // 0.4us
 #define CYCLES_800_T1H  (F_CPU / 1250001) // 0.8us
@@ -33,12 +26,8 @@ void espShow(
 
   uint8_t *p, *end, pix, mask;
   uint32_t t, time0, time1, period, c, startTime;
-
-#ifdef ESP8266
   uint32_t pinMask;
   pinMask   = _BV(pin);
-#endif
-
   p         =  pixels;
   end       =  p + numBytes;
   pix       = *p++;
@@ -62,18 +51,10 @@ void espShow(
   for(t = time0;; t = time0) {
     if(pix & mask) t = time1;                             // Bit high duration
     while(((c = _getCycleCount()) - startTime) < period); // Wait for bit start
-#ifdef ESP8266
     GPIO_REG_WRITE(GPIO_OUT_W1TS_ADDRESS, pinMask);       // Set high
-#else
-    gpio_set_level(pin, HIGH);
-#endif
     startTime = c;                                        // Save start time
     while(((c = _getCycleCount()) - startTime) < t);      // Wait high duration
-#ifdef ESP8266
     GPIO_REG_WRITE(GPIO_OUT_W1TC_ADDRESS, pinMask);       // Set low
-#else
-    gpio_set_level(pin, LOW);
-#endif
     if(!(mask >>= 1)) {                                   // Next bit/byte
       if(p >= end) break;
       pix  = *p++;


### PR DESCRIPTION
ESP32 was removed on commit https://github.com/adafruit/Adafruit_NeoPixel/commit/cd0b2217b2dfa298c39049dad8d512cf87d82ab0 , we don't need to check for esp8266 on various places anymore.