### PR TITLE
Added support for the SAMD21G17A.

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -2256,7 +2256,7 @@ void Adafruit_NeoPixel::show(void) {
 
 #elif defined(__SAMD21E17A__) || defined(__SAMD21G18A__) || \
       defined(__SAMD21E18A__) || defined(__SAMD21J18A__) || \
-      defined (__SAMD11C14A__)
+      defined(__SAMD11C14A__) || defined(__SAMD21G17A__)
   // Arduino Zero, Gemma/Trinket M0, SODAQ Autonomo
   // and others
   // Tried this with a timer/counter, couldn't quite get adequate


### PR DESCRIPTION
Similar to pull request #312, this just adds a check for the SAMD21G17A microcontroller. The single-line change is all that was required to get the library working with the SAMD21G17A using the "Generic_xx1G" variant from the [Fab SAM D|L|C Core](https://github.com/qbolsee/ArduinoCore-fab-sam). 

I tested the change on a custom PCB with a SAMD21G17A with two SK6812MINI-E NeoPixels, and it worked well.

Thanks for all you do for the community!