### PR TITLE
Fix example skipping pattern #7.

### DIFF
--- a/examples/strandtest_nodelay/strandtest_nodelay.ino
+++ b/examples/strandtest_nodelay/strandtest_nodelay.ino
@@ -68,7 +68,7 @@ void loop() {
   if((currentMillis - patternPrevious) >= patternInterval) {  //  Check for expired time
     patternPrevious = currentMillis;
     patternCurrent++;                                         //  Advance to next pattern
-    if(patternCurrent >= 7)
+    if(patternCurrent >= 8)
       patternCurrent = 0;
   }
   


### PR DESCRIPTION
The nodelay example code was skipping the final pattern available in the switch. After making this correction it seemed to work correctly.
