### PR TITLE
Moves claiming of sm to init; destructor frees pio resources.

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -82,16 +82,6 @@ Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, int16_t p, neoPixelType t)
   updateType(t);
   updateLength(n);
   setPin(p);
-#if defined(ARDUINO_ARCH_RP2040)
-  // Find a free SM on one of the PIO's
-  sm = pio_claim_unused_sm(pio, false); // don't panic
-  // Try pio1 if SM not found
-  if (sm < 0) {
-    pio = pio1;
-    sm = pio_claim_unused_sm(pio, true); // panic if no SM is free
-  }
-  init = true;
-#endif
 }
 
 /*!
@@ -120,6 +110,13 @@ Adafruit_NeoPixel::~Adafruit_NeoPixel() {
   free(pixels);
   if (pin >= 0)
     pinMode(pin, INPUT);
+
+  if(!init)
+  {
+      pio_sm_set_enabled(pio, sm, false);
+      pio_remove_program(pio, &ws2812_program, offset);
+      pio_sm_unclaim(pio, sm);
+  }
 }
 
 /*!
@@ -197,7 +194,18 @@ void Adafruit_NeoPixel::updateType(neoPixelType t) {
 #if defined(ARDUINO_ARCH_RP2040)
 void Adafruit_NeoPixel::rp2040Init(uint8_t pin, bool is800KHz)
 {
-  uint offset = pio_add_program(pio, &ws2812_program);
+    
+
+  // Find a free SM on one of the PIO's
+  sm = pio_claim_unused_sm(pio, false); // don't panic
+  // Try pio1 if SM not found
+  if (sm < 0) {
+    pio = pio1;
+    sm = pio_claim_unused_sm(pio, true); // panic if no SM is free
+  }
+  init = true;
+
+  offset = pio_add_program(pio, &ws2812_program);
 
   if (is800KHz)
   {

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -406,6 +406,7 @@ protected:
   PIO pio = pio0;
   int sm = 0;
   bool init = true;
+  uint offset;
 #endif
 };
 


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.
I've moved the claiming of a pio state machine from the constructor to the rp2040Init function.
I've added the necessary unclaiming sm functions to the destructor, dependent on whether the init function had been called.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.
No know limitations.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.
I've tested this myself, but I'd recommend testing with your examples.
