### PR TITLE
ESP32: Using RGB_BUILTIN define as pin number in the constructor fail…

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -3045,6 +3045,12 @@ if(is800KHz) {
   @param   p  Arduino pin number (-1 = no pin).
 */
 void Adafruit_NeoPixel::setPin(int16_t p) {
+#if defined(ESP32) && defined(RGB_BUILTIN)
+    if((p == RGB_BUILTIN) && (RGB_BUILTIN > SOC_GPIO_PIN_COUNT)){
+      p -= SOC_GPIO_PIN_COUNT;
+  }
+#endif
+
   if (begun && (pin >= 0))
     pinMode(pin, INPUT); // Disable existing out pin
   pin = p;


### PR DESCRIPTION
…s and resets S2 and S3

I was experimenting with a few different ESP32 boards (C3, S2, S3) and was playing with the on board neopixel and got tired of changing the pin number (C3->8, S2->18, S3->48), and noticed they had a define RGB_BUILTIN and hoped that you could use it in the constructor.

The neopixel failed to work, and on the S2 and S3 it guru-meditated. Found out they set these values as the pin number plus the count of pins...

So in setPin I checked for this and offset back to the actual pin number.

Scope of change:

void Adafruit_NeoPixel::setPin(int16_t p) {
#if defined(ESP32) && defined(RGB_BUILTIN)
    if((p == RGB_BUILTIN) && (RGB_BUILTIN > SOC_GPIO_PIN_COUNT)){
      p -= SOC_GPIO_PIN_COUNT;
  }
#endif

  if (begun && (pin >= 0))
    pinMode(pin, INPUT); // Disable existing out pin
  pin = p;
  if (begun) {
    pinMode(p, OUTPUT);
    digitalWrite(p, LOW);
  }
#if defined(__AVR__)
  port = portOutputRegister(digitalPinToPort(p));
  pinMask = digitalPinToBitMask(p);
#endif
#if defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_ARDUINO_CORE_STM32)
  gpioPort = digitalPinToPort(p);
  gpioPin = STM_LL_GPIO_PIN(digitalPinToPinName(p));
#endif
}
Added the check for ESP32 and RGB_BUILTIN and the code within it.
So should only potentially impact ESP32 builds. Note: I added the check for
RGB_BUILTIN > SOC_GPIO_PIN_COUNT
On off chance they change hot this works to be the actual pin number. But if they do, they would also need to change:
neopixelWrite(RGB_BUILTIN, r, g, b);

I built and ran the test code on an C3, S2 and an S3 dev board.
