### PR TITLE
Added code for static arrays

### DIFF
--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -217,7 +217,7 @@ class Adafruit_NeoPixel {
 public:
   // Constructor: number of LEDs, pin number, LED type
   Adafruit_NeoPixel(uint16_t n, int16_t pin = 6,
-                    neoPixelType type = NEO_GRB + NEO_KHZ800);
+                    neoPixelType type = NEO_GRB + NEO_KHZ800, uint8_t *staticArray = nullptr);
   Adafruit_NeoPixel(void);
   ~Adafruit_NeoPixel();
 
@@ -230,7 +230,7 @@ public:
   void fill(uint32_t c = 0, uint16_t first = 0, uint16_t count = 0);
   void setBrightness(uint8_t);
   void clear(void);
-  void updateLength(uint16_t n);
+  void updateLength(uint16_t n, uint8_t *staticArray = nullptr);
   void updateType(neoPixelType t);
   /*!
     @brief   Check whether a call to show() will start sending data
@@ -383,6 +383,7 @@ protected:
 #ifdef NEO_KHZ400 // If 400 KHz NeoPixel support enabled...
   bool is800KHz; ///< true if 800 KHz pixels
 #endif
+  bool isStatic;      ///< true if a static array is used
   bool begun;         ///< true if begin() previously called
   uint16_t numLEDs;   ///< Number of RGB LEDs in strip
   uint16_t numBytes;  ///< Size of 'pixels' buffer below


### PR DESCRIPTION
Added in provision to incorporate the use of static arrays for LEDs. I was working on a project that used 11 different strips of Neo pixels (this was the  144 LED/m where it is recommended to use only 1 meter at a time). Since I used 11 strips, I needed 11 different instances of the Adafruit class and with this being dynamic memory on a MCU, this killed my heap. Even the ESP32 had a hard time.

But, once I removed the dynamic aspect from the library, everything worked. This code will be valuable to those that use more then 1 strip. I also have default arguments to be backward compatible with existing code. 

