### PR TITLE
[Bugfix] Correct mis-matched function signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Doxyfile*
 doxygen_sqlite3.db
 html
+.vscode/*

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -229,10 +229,10 @@ void  Adafruit_NeoPixel::rp2040Show(uint8_t pin, uint8_t *pixels, uint32_t numBy
 
 #if defined(ESP8266)
 // ESP8266 show() is external to enforce ICACHE_RAM_ATTR execution
-extern "C" IRAM_ATTR void espShow(uint16_t pin, uint8_t *pixels,
+extern "C" IRAM_ATTR void espShow(int16_t pin, uint8_t *pixels,
                                   uint32_t numBytes, uint8_t type);
 #elif defined(ESP32)
-extern "C" void espShow(uint16_t pin, uint8_t *pixels, uint32_t numBytes,
+extern "C" void espShow(int16_t pin, uint8_t *pixels, uint32_t numBytes,
                         uint8_t type);
 #endif // ESP8266
 

--- a/esp.c
+++ b/esp.c
@@ -34,7 +34,7 @@
 
 #ifdef HAS_ESP_IDF_5
 
-void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
+void espShow(int16_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
   rmt_data_t led_data[numBytes * 8];
 
   if (!rmtInit(pin, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 10000000)) {
@@ -131,7 +131,7 @@ static void IRAM_ATTR ws2812_rmt_adapter(const void *src, rmt_item32_t *dest, si
     *item_num = num;
 }
 
-void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
+void espShow(int16_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
     // Reserve channel
     rmt_channel_t channel = ADAFRUIT_RMT_CHANNEL_MAX;
     for (size_t i = 0; i < ADAFRUIT_RMT_CHANNEL_MAX; i++) {

--- a/esp8266.c
+++ b/esp8266.c
@@ -18,10 +18,10 @@ static inline uint32_t _getCycleCount(void) {
 
 #ifdef ESP8266
 IRAM_ATTR void espShow(
- uint8_t pin, uint8_t *pixels, uint32_t numBytes, __attribute__((unused)) boolean is800KHz) {
+ int16_t pin, uint8_t *pixels, uint32_t numBytes, __attribute__((unused)) boolean is800KHz) {
 #else
 void espShow(
- uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
+ int16_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
 #endif
 
 #define CYCLES_800_T0H  (F_CPU / 2500001) // 0.4us

--- a/kendyte_k210.c
+++ b/kendyte_k210.c
@@ -11,7 +11,7 @@
 #include "sysctl.h"
 
 void  k210Show(
-    uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz)
+    int16_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz)
 {
 
 #define CYCLES_800_T0H (sysctl_clock_get_freq(SYSCTL_CLOCK_CPU) / 2500000) // 0.4us


### PR DESCRIPTION
Features:
- Correct mismatched function signatures (int vs uint...😮), using the type of argument used/expected.
- Add `.vscode` to `.gitignore` file

Has been tested on ESP8266 hardware. (For ESP32 support we use a different library.)