### PR TITLE
rp2040 check for available pio instruction memory

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -84,9 +84,9 @@ Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, int16_t p, neoPixelType t)
   setPin(p);
 #if defined(ARDUINO_ARCH_RP2040)
   #ifdef NEO_KHZ400
-  rp2040Init(p, is800KHz);
+  rp2040Init(is800KHz);
   #else
-  rp2040Init(p, true);
+  rp2040Init(true);
   #endif
 #endif
 }
@@ -215,11 +215,11 @@ void  Adafruit_NeoPixel::rp2040PioProgramInit(uint8_t pin, bool is800KHz) {
     ws2812_program_init(pio, pio_sm, pio_program_offset, pin, 400000, 8);
   }
 }
-void Adafruit_NeoPixel::rp2040Init(uint8_t pin, bool is800KHz)
+void Adafruit_NeoPixel::rp2040Init(bool is800KHz)
 {
   // Find a PIO with enough available space in its instruction memory
   pio = pio0;
-  if (!pio_can_add_program(this->pio, &ws2812_program)) {
+  if (!pio_can_add_program(pio, &ws2812_program)) {
     pio = pio1;
   }
 
@@ -238,9 +238,9 @@ void  Adafruit_NeoPixel::rp2040Show(uint8_t pin, uint8_t *pixels, uint32_t numBy
   if (init)
   {
     // On first pass through initialise the PIO
-    rp2040Init(pin, is800KHz);
+    rp2040Init(is800KHz);
   }
-
+  
   while(numBytes--)
     // Bits for transmission must be shifted to top 8 bits
     pio_sm_put_blocking(pio, pio_sm, ((uint32_t)*pixels++)<< 24);
@@ -3152,7 +3152,7 @@ void Adafruit_NeoPixel::setPin(int16_t p) {
   #if defined(ARDUINO_ARCH_RP2040)
     if (!init)
       pio_sm_set_enabled(pio, pio_sm, false);
-  #endif
+      #endif
     pinMode(pin, INPUT); // Disable existing out pin
   }
   pin = p;

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -82,13 +82,6 @@ Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, int16_t p, neoPixelType t)
   updateType(t);
   updateLength(n);
   setPin(p);
-#if defined(ARDUINO_ARCH_RP2040)
-  #ifdef NEO_KHZ400
-  rp2040Init(is800KHz);
-  #else
-  rp2040Init(true);
-  #endif
-#endif
 }
 
 /*!
@@ -3155,6 +3148,17 @@ void Adafruit_NeoPixel::setPin(int16_t p) {
       #endif
     pinMode(pin, INPUT); // Disable existing out pin
   }
+
+  #if defined(ARDUINO_ARCH_RP2040)
+  if (init) {
+    #ifdef NEO_KHZ400
+    rp2040Init(is800KHz);
+    #else
+    rp2040Init(true);
+    #endif
+  }
+  #endif
+  
   pin = p;
   if (begun) {
     pinMode(p, OUTPUT);

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -376,7 +376,7 @@ public:
 private:
 #if defined(ARDUINO_ARCH_RP2040)
   void  rp2040PioProgramInit(uint8_t pin, bool is800KHz);
-  void  rp2040Init(uint8_t pin, bool is800KHz);
+  void  rp2040Init(bool is800KHz);
   void  rp2040Show(uint8_t pin, uint8_t *pixels, uint32_t numBytes, bool is800KHz);
 #endif
 

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -375,6 +375,7 @@ public:
 
 private:
 #if defined(ARDUINO_ARCH_RP2040)
+  void  rp2040PioProgramInit(uint8_t pin, bool is800KHz);
   void  rp2040Init(uint8_t pin, bool is800KHz);
   void  rp2040Show(uint8_t pin, uint8_t *pixels, uint32_t numBytes, bool is800KHz);
 #endif

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -404,7 +404,8 @@ protected:
 #endif
 #if defined(ARDUINO_ARCH_RP2040)
   PIO pio = pio0;
-  int sm = 0;
+  int pio_sm = -1;
+  uint pio_program_offset = 0;
   bool init = true;
 #endif
 };


### PR DESCRIPTION
Hi All,

On the RP2040(W) the class caused a PANIC when I tried to use it together with another library that was also using the PIO. I initialized the other library first and it happened to use all of the instruction memory of pio0. The original code just checked for available SM, but not for pio memory.

I changed the rp2040 init code to check for available memory first on pio0, if that fails then it tries to load the pio program to pio1's memory and if that also fails then the raspberry SDK throws PANIC.
I also added clean up code to the destructor to free the pio resources.

This is a compatible change and effects only the rp2040 devices.

Probably already known limitation:
With the current pio program one rp2040 can only handle 8 Neopixel strips and the pio program is going to be loaded separately for each instance.