### PR TITLE
Add XMC1400_Arduino_Kit Support to Adafruit NeoPixel Library

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -2336,7 +2336,7 @@ void Adafruit_NeoPixel::show(void) {
 #endif
 
 //----
-#elif defined(XMC1100_XMC2GO) || defined(XMC1100_H_BRIDGE2GO) || defined(XMC1100_Boot_Kit)  || defined(XMC1300_Boot_Kit)
+#elif defined(XMC1100_XMC2GO) || defined(XMC1400_Arduino_Kit) || defined(XMC1100_H_BRIDGE2GO) || defined(XMC1100_Boot_Kit)  || defined(XMC1300_Boot_Kit)
 
   // XMC1100/1200/1300 with ARM Cortex M0 are running with 32MHz, XMC1400 runs with 48MHz so may not work
   // Tried this with a timer/counter, couldn't quite get adequate


### PR DESCRIPTION
## Scope of Change
This pull request introduces support for the XMC1400_Arduino_Kit within the Adafruit NeoPixel library. The change consists of adding a single define directive that enables the NeoPixel library to interface with the XMC1400_Arduino_Kit hardware.

### Modified Parts
- `Adafruit_NeoPixel.cpp`: Added conditional directive to check for the XMC1400_Arduino_Kit definition and apply necessary initializations and configurations specific to XMC11xx based boards.

## Known Limitations
This change includes only XMC1400_Arduino_Kit and future XMC11xx based boards will need to be added separately.

## Tests and Examples
The change was tested on the affected board using the given library examples in Arduino.

**Test Environment Details:**
- Hardware: XMC1400_Arduino_Kit
- IDE: Arduino IDE version `2.3.1`
- Library Version: Adafruit NeoPixel Library version `1.11.0`

Thanks in advance for considering this PR.

Best regards
Julian