### PR TITLE
fix setPin() for RP2040

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -3127,13 +3127,23 @@ if(is800KHz) {
   @param   p  Arduino pin number (-1 = no pin).
 */
 void Adafruit_NeoPixel::setPin(int16_t p) {
-  if (begun && (pin >= 0))
-    pinMode(pin, INPUT); // Disable existing out pin
-  pin = p;
   if (begun) {
     pinMode(p, OUTPUT);
     digitalWrite(p, LOW);
   }
+  #if defined(ARDUINO_ARCH_RP2040)
+  if (!init)
+  {
+    delayMicroseconds(100);
+    pio_gpio_init(pio, p);
+    pio_sm_set_consecutive_pindirs(pio, sm, p, 1, true);
+    pio_sm_set_sideset_pins(pio, sm, p);
+  }
+  #endif
+  if (begun && (pin >= 0))
+    pinMode(pin, INPUT); // Disable existing out pin
+  pin = p;
+  
 #if defined(__AVR__)
   port = portOutputRegister(digitalPinToPort(p));
   pinMask = digitalPinToBitMask(p);


### PR DESCRIPTION
## change
fix setPin() for rp2040. Make it possible for rp2040 to support more than 8 led strips. (as #329 mentioned)

## modification:
~~~cpp
  #if defined(ARDUINO_ARCH_RP2040)
  if (!init)
  {
    delayMicroseconds(100);
    pio_gpio_init(pio, p);
    pio_sm_set_consecutive_pindirs(pio, sm, p, 1, true);
    pio_sm_set_sideset_pins(pio, sm, p);
  }
  #endif
~~~

the code uses pio_sm_set_sideset_pins function to reconfigure the ouput pin of the state machine on the fly.  
delayMicroseconds(100) is needed because we need to make sure that the state machine has finished sending bits on the previous pin.  
I also rearrange the order of the code for the same reason.  

## test:
~~~cpp
#include "Adafruit_NeoPixel.h"

#define PIN0 0
#define PIN1 1

#define NUMPIXELS 16

Adafruit_NeoPixel pixels(NUMPIXELS, PIN0, NEO_GRB + NEO_KHZ800);

void setup() {
  pixels.begin();
  pixels.clear();
}

void loop() {
  pixels.setPin(PIN0);
  pixels.show();   // Send the updated pixel colors to the hardware.
  pixels.setPin(PIN1);
  pixels.show();   // Send the updated pixel colors to the hardware.
}
~~~

And it worked fine.  

signals are being sent out alternately from the two ports as expected:  
![ws2812](https://github.com/adafruit/Adafruit_NeoPixel/assets/103294894/1f24f670-a4d5-40f0-901e-6aa41877a9b4)

scale up view:  
![ws2812_scale_up_view](https://github.com/adafruit/Adafruit_NeoPixel/assets/103294894/1f49b2ba-af37-4e96-8860-634f40fcab90)