### PR TITLE
RMT Buffer Allocation Fix (Thread-Safe) for Issue #375

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -92,6 +92,11 @@ Adafruit_NeoPixel::Adafruit_NeoPixel(uint16_t n, int16_t p, neoPixelType t)
   }
   init = true;
 #endif
+#if defined(ESP32)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+  espInit();
+#endif
+#endif
 }
 
 /*!
@@ -234,6 +239,7 @@ extern "C" IRAM_ATTR void espShow(uint16_t pin, uint8_t *pixels,
 #elif defined(ESP32)
 extern "C" void espShow(uint16_t pin, uint8_t *pixels, uint32_t numBytes,
                         uint8_t type);
+
 #endif // ESP8266
 
 #if defined(K210)
@@ -3553,4 +3559,4 @@ neoPixelType Adafruit_NeoPixel::str2order(const char *v) {
   }
   if (w < 0) w = r; // If 'w' not specified, duplicate r bits
   return (w << 6) | (r << 4) | ((g & 3) << 2) | (b & 3);
-} 
+}

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -208,6 +208,15 @@ static const uint8_t PROGMEM _NeoPixelGammaTable[256] = {
     218, 220, 223, 225, 227, 230, 232, 235, 237, 240, 242, 245, 247, 250, 252,
     255};
 
+/* Declare external methods required by the Adafruit_NeoPixel implementation
+    for specific hardware/library versions
+*/
+#if defined(ESP32)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+extern "C" void espInit();
+#endif
+#endif
+
 /*!
     @brief  Class that stores state and functions for interacting with
             Adafruit NeoPixels and compatible devices.

--- a/esp.c
+++ b/esp.c
@@ -31,40 +31,88 @@
 #endif
 
 
-
 #ifdef HAS_ESP_IDF_5
 
 void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
-  rmt_data_t led_data[numBytes * 8];
+  // Note: Because rmtPin is shared between all instances, we will
+  //  end up releasing/initializing the RMT channels each time we
+  //  invoke on different pins. This is probably ok, just not
+  //  efficient. led_data is shared between all instances but will
+  //  be allocated with enough space for the largest instance; data
+  //  is not used beyond the mutex lock so this should be fine.
 
-  if (!rmtInit(pin, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 10000000)) {
-    log_e("Failed to init RMT TX mode on pin %d", pin);
-    return;
+#define SEMAPHORE_TIMEOUT_MS 50
+
+  static rmt_data_t *led_data = NULL;
+  static uint32_t led_data_size = 0;
+  static int rmtPin = -1;
+  static SemaphoreHandle_t show_mutex = NULL;
+
+  if (!show_mutex) {
+    show_mutex = xSemaphoreCreateMutex();
   }
 
-  int i=0;
-  for (int b=0; b < numBytes; b++) {
-    for (int bit=0; bit<8; bit++){
-      if ( pixels[b] & (1<<(7-bit)) ) {
-        led_data[i].level0 = 1;
-        led_data[i].duration0 = 8;
-        led_data[i].level1 = 0;
-        led_data[i].duration1 = 4;
+  if (xSemaphoreTake(show_mutex, SEMAPHORE_TIMEOUT_MS / portTICK_PERIOD_MS) == pdTRUE) {
+    uint32_t requiredSize = numBytes * 8;
+    if (requiredSize > led_data_size) {
+      free(led_data);
+      if (led_data = (rmt_data_t *)malloc(requiredSize * sizeof(rmt_data_t))) {
+        led_data_size = requiredSize;
       } else {
-        led_data[i].level0 = 1;
-        led_data[i].duration0 = 4;
-        led_data[i].level1 = 0;
-        led_data[i].duration1 = 8;
+        led_data_size = 0;
       }
-      i++;
+    } else if (requiredSize == 0) {
+      // To release RMT resources (RMT channels and led_data), call
+      //  .updateLength(0) to set number of pixels/bytes to zero,
+      //  then call .show() to invoke this code and free resources.
+      free(led_data);
+      led_data = NULL;
+      if (rmtPin >= 0) {
+        rmtDeinit(rmtPin);
+        rmtPin = -1;
+      }
+      led_data_size = 0;
     }
+
+    if (led_data_size > 0 && requiredSize <= led_data_size) {
+      if (pin != rmtPin) {
+        if (rmtPin >= 0) {
+          rmtDeinit(rmtPin);
+          rmtPin = -1;
+        }
+        if (!rmtInit(pin, RMT_TX_MODE, RMT_MEM_NUM_BLOCKS_1, 10000000)) {
+          log_e("Failed to init RMT TX mode on pin %d", pin);
+          return;
+        }
+        rmtPin = pin;
+      }
+
+      if (rmtPin >= 0) {
+        int i=0;
+        for (int b=0; b < numBytes; b++) {
+          for (int bit=0; bit<8; bit++){
+            if ( pixels[b] & (1<<(7-bit)) ) {
+              led_data[i].level0 = 1;
+              led_data[i].duration0 = 8;
+              led_data[i].level1 = 0;
+              led_data[i].duration1 = 4;
+            } else {
+              led_data[i].level0 = 1;
+              led_data[i].duration0 = 4;
+              led_data[i].level1 = 0;
+              led_data[i].duration1 = 8;
+            }
+            i++;
+          }
+        }
+
+        rmtWrite(pin, led_data, numBytes * 8, RMT_WAIT_FOR_EVER);
+      }
+    }
+
+    xSemaphoreGive(show_mutex);
   }
-
-  //pinMode(pin, OUTPUT);  // don't do this, will cause the rmt to disable!
-  rmtWrite(pin, led_data, numBytes * 8, RMT_WAIT_FOR_EVER);
 }
-
-
 
 #else
 
@@ -219,6 +267,6 @@ void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) 
 }
 
 #endif // ifndef IDF5
- 
+
 
 #endif // ifdef(ESP32)


### PR DESCRIPTION
**_NOTE: This is a thread-safe version of pull-request #392: It is essentially the same code with a mutex added to protect the code from multiple threads._**

This pull request addresses issue #375 [pixel.show() crash with more than 73 pixel on ESP32s3]

After reviewing the code and also getting some helpful feedback from the Espressif Forums (https://www.esp32.com/viewtopic.php?f=13&t=40270) and @robertlipe it was determined that the code in esp.c for handling the RMT item buffers when using the IDF v5 framework was allocating too much space on the stack when using more than 70ish pixels.

This pull request addresses that issue by allocating the RMT buffers from the heap instead. It will attempt to allocate a single block of memory to accommodate the largest configured instance (sharing the buffer between instances is fine, as the buffer is completely populated each each time the `espShow()` method is called).

I also took the time to improve the channel allocation management, previously the RMT channels were initialized on each call to `espShow()`, now the RMT channels are only de-initialized and re-initialized whenever the output pin is changed.

Finally, I was concerned about problems that may be caused by allocating large buffers on the heap without giving the user any way to free that memory, so the code allows a user to free that memory (and also release the RMT channels) by setting the number of pixels to zero using `.updateLength(0)` and then calling `.show()`. This will de-allocate the heap memory used for the RMT buffers and release the RMT channels held by driver. They will automatically be re-allocated if needed when setting the number of pixels back to a non-zero value.