### PR TITLE
add ch32 support

### DIFF
--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -398,7 +398,7 @@ protected:
   volatile uint8_t *port; ///< Output PORT register
   uint8_t pinMask;        ///< Output PORT bitmask
 #endif
-#if defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_ARDUINO_CORE_STM32)
+#if defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_ARDUINO_CORE_STM32) || defined(ARDUINO_ARCH_CH32)
   GPIO_TypeDef *gpioPort; ///< Output GPIO PORT
   uint32_t gpioPin;       ///< Output GPIO PIN
 #endif


### PR DESCRIPTION
add support for ch32 core with bit banging implementation. Tested with ch32v203g6 qtpy with neopixel featherwing (32 pixel) work with multiple F_CPU: 144mhz, 120mhz, 96mhz, 72mhz, 56mhz

@ladyada 