### PR TITLE
Removed unused `bit` variable for SAMD51

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -2657,7 +2657,7 @@ if(is800KHz) {
 
 #elif defined(__SAMD51__) // M4
 
-  uint8_t *ptr, *end, p, bitMask, portNum, bit;
+  uint8_t *ptr, *end, p, bitMask, portNum;
   uint32_t pinMask;
 
   portNum = g_APinDescription[pin].ulPort;


### PR DESCRIPTION
## Scope of Change
Removed unused `bit` variable for SAMD51 microcontrollers in `Adafruit_NeoPixel.cpp`

## Limitations of Change
Change only applies to SAMD51 microcontrollers

## Other Notes
Fixes issue #359, PR #235 was previously opened to fix this but was self-closed
