### PR TITLE
Fix: ESP32 espShow() doesn't de-init RMT

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -125,7 +125,7 @@ Adafruit_NeoPixel::~Adafruit_NeoPixel() {
   free(pixels);
   #ifdef ARDUINO_ARCH_ESP32
   // Release RMT resources (RMT channel and led_data)
-  espShow(pin, NULL, 0, true, NEO_RGB);
+  espShow(pin, NULL, 0, true);
   #endif
   if (pin >= 0)
     pinMode(pin, INPUT);

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -417,10 +417,6 @@ extern "C" void k210Show(uint8_t pin, uint8_t *pixels, uint32_t numBytes,
            very device-specific peripherals to work around it.
 */
 void Adafruit_NeoPixel::show(void) {
-
-  if (!pixels)
-    return;
-
   // Data latch = 300+ microsecond pause in the output stream. Rather than
   // put a delay at the end of the function, the ending time is noted and
   // the function will simply hold off (if needed) on issuing the

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -417,6 +417,12 @@ extern "C" void k210Show(uint8_t pin, uint8_t *pixels, uint32_t numBytes,
            very device-specific peripherals to work around it.
 */
 void Adafruit_NeoPixel::show(void) {
+
+#ifndef ARDUINO_ARCH_ESP32
+  if (!pixels)
+    return;
+#endif
+
   // Data latch = 300+ microsecond pause in the output stream. Rather than
   // put a delay at the end of the function, the ending time is noted and
   // the function will simply hold off (if needed) on issuing the

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -125,7 +125,7 @@ Adafruit_NeoPixel::~Adafruit_NeoPixel() {
   free(pixels);
   #ifdef ARDUINO_ARCH_ESP32
   // Release RMT resources (RMT channel and led_data)
-  espShow(pin, NULL, 0, true);
+  espShow(pin, NULL, 0, true, NEO_RGB);
   #endif
   if (pin >= 0)
     pinMode(pin, INPUT);

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -123,6 +123,10 @@ Adafruit_NeoPixel::Adafruit_NeoPixel()
 */
 Adafruit_NeoPixel::~Adafruit_NeoPixel() {
   free(pixels);
+  #ifdef ARDUINO_ARCH_ESP32
+  // Release RMT resources (RMT channel and led_data)
+  espShow(pin, NULL, 0, true);
+  #endif
   if (pin >= 0)
     pinMode(pin, INPUT);
 }
@@ -418,10 +422,8 @@ extern "C" void k210Show(uint8_t pin, uint8_t *pixels, uint32_t numBytes,
 */
 void Adafruit_NeoPixel::show(void) {
 
-#ifndef ARDUINO_ARCH_ESP32
   if (!pixels)
     return;
-#endif
 
   // Data latch = 300+ microsecond pause in the output stream. Rather than
   // put a delay at the end of the function, the ending time is noted and

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -122,11 +122,14 @@ Adafruit_NeoPixel::Adafruit_NeoPixel()
   @brief   Deallocate Adafruit_NeoPixel object, set data pin back to INPUT.
 */
 Adafruit_NeoPixel::~Adafruit_NeoPixel() {
+#ifdef ARDUINO_ARCH_ESP32
+  // Release RMT resources (RMT channels and led_data)
+  // by indirectly calling into espShow()
+  memset(pixels, 0, numBytes);
+  numLEDs = numBytes = 0;
+  show();
+#endif
   free(pixels);
-  #ifdef ARDUINO_ARCH_ESP32
-  // Release RMT resources (RMT channel and led_data)
-  espShow(pin, NULL, 0, true);
-  #endif
   if (pin >= 0)
     pinMode(pin, INPUT);
 }


### PR DESCRIPTION
@ladyada  The issue fixed by this PR is allowing a `new` NeoPixel object on ESP32 to be destroyed and re-created. The core issue is within `esp.c`'s `espShow()` implementation for IDF 5+ which looks like it was modified/written by [teknynja](https://github.com/adafruit/Adafruit_NeoPixel/commits?author=teknynja).

What should work:
* Calling pixel.updateLength(0) then pixel.show() [should be invoked in user-code to release RMT resources.](https://github.com/adafruit/Adafruit_NeoPixel/blob/master/esp.c#L61:L64)

Why this does not work:
* When calling `updateLength()` with a value of `0`, the function [frees the `pixels` buffer](https://github.com/adafruit/Adafruit_NeoPixel/blob/master/Adafruit_NeoPixel.cpp#L152)
* Calling `show() directly after will [early-return since the first check within `show()` is for `pixels`](https://github.com/adafruit/Adafruit_NeoPixel/blob/master/Adafruit_NeoPixel.cpp#L421)
* Because of this, espShow() will never [release RMT resources] or re-attach them (https://github.com/adafruit/Adafruit_NeoPixel/blob/master/esp.c#L61) as expected.
* When the NeoPixel object is destroyed and re-created, the object will fail to execute `show()` calls because the RMT was neither released or re-attached properly.

Addresses:
https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/691
https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/684