### PR TITLE
fix build for RP2350 target with RISC-V architecture

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -3278,6 +3278,9 @@ if(is800KHz) {
 
 #elif defined(ARDUINO_ARCH_CH32)
   ch32Show(gpioPort, gpioPin, pixels, numBytes, is800KHz);
+#elif defined(ARDUINO_ARCH_RP2040) && defined(__riscv)
+  // Use PIO
+  rp2040Show(pin, pixels, numBytes, is800KHz);
 #else
 #error Architecture not supported
 #endif


### PR DESCRIPTION
Closes https://github.com/adafruit/Adafruit_NeoPixel/issues/406

It is confirmed to work nicely with Raspberry Pico 2W after uploading of RISC-V UF2 binary


![image](https://github.com/user-attachments/assets/baf5c989-f5df-4b5a-a8a6-7cfa68ee70d4)
