### PR TITLE
FIX: ESP32 compatibility 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Doxyfile*
 doxygen_sqlite3.db
 html
+**/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+idf_component_register(
+    SRCS
+        "Adafruit_NeoPixel.cpp"
+        "esp.c"
+        "esp8266.c"
+        "kendyte_k210.c"
+
+    INCLUDE_DIRS
+        "."
+
+    REQUIRES
+        "arduino"
+)

--- a/esp.c
+++ b/esp.c
@@ -53,7 +53,8 @@ void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) 
     uint32_t requiredSize = numBytes * 8;
     if (requiredSize > led_data_size) {
       free(led_data);
-      if (led_data = (rmt_data_t *)malloc(requiredSize * sizeof(rmt_data_t))) {
+      led_data = (rmt_data_t *)malloc(requiredSize * sizeof(rmt_data_t));
+      if (led_data) {
         led_data_size = requiredSize;
       } else {
         led_data_size = 0;


### PR DESCRIPTION
# Scope of Change:
This pull request addresses a compile-time error encountered in the library when used with the ESP-IDF. The specific issue arises from the use of an assignment within an `if` statement, which results in a warning being treated as an error by the compiler.

The original line of code:
```c
if (led_data = (rmt_data_t *)malloc(requiredSize * sizeof(rmt_data_t))) {
```
has been modified to separate the assignment from the conditional check. The updated code is as follows:
```c
led_data = (rmt_data_t *)malloc(requiredSize * sizeof(rmt_data_t));
if (led_data) {
```
This change ensures that the memory allocation is checked properly, thereby preventing potential runtime errors if the allocation fails.

**I have also added `**/build` to `.gitignore`, as this directory is generated when building the project with `idf.py build`.**

## CMake
NOT ADDED IN THIS PR, but I believe a root `CMakeLists.txt` file could be created with similar configuration as the following for `$ idf.py build`:
```
idf_component_register(
    SRCS
        "Adafruit_NeoPixel.cpp"
        "esp.c"
        "esp8266.c"
        "kendyte_k210.c"

    INCLUDE_DIRS
        "."

    REQUIRES
        "arduino"
)
```