### PR TITLE
Fix pio related compilation issues for BSP's with older Pico SDKs

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -126,7 +126,7 @@ Adafruit_NeoPixel::~Adafruit_NeoPixel() {
 #endif
 
 
-#if defined(ARDUINO_ARCH_RP2040)
+#if defined(USE_RP2040_PIO)
   // Release any PIO
   rp2040releasePIO();
 #endif
@@ -149,14 +149,13 @@ bool Adafruit_NeoPixel::begin(void) {
     return false;
   }
 
-#if defined(ARDUINO_ARCH_RP2040)
+#if defined(USE_RP2040_PIO)
   // if we're calling begin() again, unclaim any existing PIO resc.
   rp2040releasePIO();
   if (! rp2040claimPIO()) {
     begun = false;
     return false;
   }
-  
 #endif
 
   begun = true;
@@ -1890,7 +1889,7 @@ void Adafruit_NeoPixel::show(void) {
   }
     // ARM MCUs -- Teensy 3.0, 3.1, LC, Arduino Due, RP2040 -------------------
 
-#elif defined(ARDUINO_ARCH_RP2040)
+#elif defined(USE_RP2040_PIO)
   // Use PIO
   rp2040Show(pixels, numBytes);
 
@@ -3365,7 +3364,7 @@ if(is800KHz) {
 
 #elif defined(ARDUINO_ARCH_CH32)
   ch32Show(gpioPort, gpioPin, pixels, numBytes, is800KHz);
-#elif defined(ARDUINO_ARCH_RP2040) && defined(__riscv)
+#elif defined(USE_RP2040_PIO) && defined(__riscv)
   rp2040Show(pixels, numBytes);  // Use PIO
 #else
 #error Architecture not supported

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -54,7 +54,8 @@
 #include "pinDefinitions.h"
 #endif
 
-#if defined(ARDUINO_ARCH_RP2040)
+#if defined(ARDUINO_ARCH_RP2040) && (PICO_SDK_VERSION_MAJOR > 1)
+#define USE_RP2040_PIO
 #include <stdlib.h>
 #include "hardware/pio.h"
 #include "hardware/clocks.h"
@@ -383,7 +384,7 @@ public:
   static neoPixelType str2order(const char *v);
 
 private:
-#if defined(ARDUINO_ARCH_RP2040)
+#if defined(USE_RP2040_PIO)
   bool   rp2040claimPIO(void);
   void   rp2040releasePIO(void);
   void   rp2040Show(uint8_t *pixels, uint32_t numBytes);

--- a/Adafruit_Neopixel_RP2.cpp
+++ b/Adafruit_Neopixel_RP2.cpp
@@ -1,5 +1,3 @@
-//#if defined(ARDUINO_ARCH_RP2040)  // RP2040 specific driver
-//&& (PICO_SDK_VERSION_MAJOR > 1)
 #include "Adafruit_NeoPixel.h"
 #if defined(USE_RP2040_PIO)
 

--- a/Adafruit_Neopixel_RP2.cpp
+++ b/Adafruit_Neopixel_RP2.cpp
@@ -1,13 +1,14 @@
-#if defined(ARDUINO_ARCH_RP2040)// RP2040 specific driver
-
+//#if defined(ARDUINO_ARCH_RP2040)  // RP2040 specific driver
+//&& (PICO_SDK_VERSION_MAJOR > 1)
 #include "Adafruit_NeoPixel.h"
+#if defined(USE_RP2040_PIO)
 
 bool Adafruit_NeoPixel::rp2040claimPIO(void) {
   // Find a PIO with enough available space in its instruction memory
   pio = NULL;
 
-  if (! pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, 
-                                                         &pio, &pio_sm, &pio_program_offset, 
+  if (! pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program,
+                                                         &pio, &pio_sm, &pio_program_offset,
                                                          pin, 1, true)) {
     pio = NULL;
     pio_sm = -1;
@@ -16,7 +17,7 @@ bool Adafruit_NeoPixel::rp2040claimPIO(void) {
   }
 
   // yay ok!
-  
+
   if (is800KHz) {
     // 800kHz, 8 bit transfers
     ws2812_program_init(pio, pio_sm, pio_program_offset, pin, 800000, 8);
@@ -29,7 +30,7 @@ bool Adafruit_NeoPixel::rp2040claimPIO(void) {
 }
 
 void Adafruit_NeoPixel::rp2040releasePIO(void) {
-  if (pio == NULL) 
+  if (pio == NULL)
     return;
 
   pio_remove_program_and_unclaim_sm(&ws2812_program, pio, pio_sm,  pio_program_offset);


### PR DESCRIPTION
Potential fix for #437 

Updates preproc to check for Pico SDK major version and only support pio usage if at least 2.x.

Functional check on a Metro RP2350 and a 12 pixel ring on D2 using `strandtest` example sketch.

Only did a compilation check for Arduino Nano RP2040 Connect.