### PR TITLE
 SPI interface for the ESP32-C2 / C61

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -385,10 +385,10 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
 #if defined(ESP8266)
 // ESP8266 show() is external to enforce ICACHE_RAM_ATTR execution
 extern "C" IRAM_ATTR void espShow(uint16_t pin, uint8_t *pixels,
-                                  uint32_t numBytes, uint8_t type);
+                                  uint32_t numBytes, uint8_t type, uint32_t maxCurrent, uint32_t CurrentPerLED, boolean Dynamic);
 #elif defined(ESP32)
 extern "C" void espShow(uint16_t pin, uint8_t *pixels, uint32_t numBytes,
-                        uint8_t type);
+                        uint8_t type, uint32_t maxCurrent, uint32_t CurrentPerLED, boolean Dynamic);
 
 #endif // ESP8266
 
@@ -3210,7 +3210,7 @@ if(is800KHz) {
   // ESP8266 ----------------------------------------------------------------
 
   // ESP8266 show() is external to enforce ICACHE_RAM_ATTR execution
-  espShow(pin, pixels, numBytes, is800KHz);
+  espShow(pin, pixels, numBytes, is800KHz, maxCurrent, CurrentPerLED,DynamicCurrent);
 
 #elif defined(KENDRYTE_K210)
 
@@ -3692,7 +3692,26 @@ void Adafruit_NeoPixel::setBrightness(uint8_t b) {
   @return  Brightness value: 0 = minimum (off), 255 = maximum.
 */
 uint8_t Adafruit_NeoPixel::getBrightness(void) const { return brightness - 1; }
-
+/*!
+  @brief   Set the maximum current (in milliamps) that the strip should draw, and
+           the estimated current per LED. This is used to limit brightness
+           when a large number of LEDs are used, to avoid overloading the
+           power supply or damaging the strip. The library will automatically
+           scale back brightness to stay within the specified current limit.
+  @param   mAmaxCurrent  Maximum current in milliamps that the strip should draw.
+  @param   mAPerLED      Estimated current per LED in milliamps. 
+           This should be the maximum current draw of a single LED at full brightness, 
+           which is typically around 60 mA for RGB Device and 80 mA for RGBW Device, 
+           This will be 20 mA or for a LED, so adjust accordingly,
+           but check your specific strip's datasheet for accurate values.
+  @param   Dynamic  If true, the library will dynamically adjust brightness to stay within the current limit as the number of lit LEDs changes.
+*/
+void Adafruit_NeoPixel::setMaxCurrent(uint32_t mAmaxCurrent,uint32_t mAPerLED,bool Dynamic)
+{
+  maxCurrent = mAmaxCurrent;
+  CurrentPerLED = mAPerLED;
+  DynamicCurrent = Dynamic;
+}
 /*!
   @brief   Fill the whole NeoPixel strip with 0 / black / off.
 */

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -233,6 +233,7 @@ public:
   void setPixelColor(uint16_t n, uint32_t c);
   void fill(uint32_t c = 0, uint16_t first = 0, uint16_t count = 0);
   void setBrightness(uint8_t);
+  void setMaxCurrent(uint32_t mAmaxCurrent,uint32_t mAPerLED=20, bool DynamicCurrent=true);
   void clear(void);
   void updateLength(uint16_t n);
   void updateType(neoPixelType t);
@@ -403,7 +404,10 @@ protected:
   uint8_t bOffset;    ///< Index of blue byte
   uint8_t wOffset;    ///< Index of white (==rOffset if no white)
   uint32_t endTime;   ///< Latch timing reference
-
+  uint32_t maxCurrent=0xffffffff;  ///< Maximum power (in mA) allowed to be delivered to LEDs
+  uint32_t CurrentPerLED=20;  ///< Estimated maximum power (in mA) consumed by each LED at full brightness 
+  bool DynamicCurrent=true; /// to dynamically adjust brightness to stay within maxCurrent
+                            /// if false, brightness will alway be adjusted based on maxCurrent
 #ifdef __AVR__
   volatile uint8_t *port; ///< Output PORT register
   uint8_t pinMask;        ///< Output PORT bitmask

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Adafruit NeoPixel Library [![Build Status](https://github.com/adafruit/Adafruit_NeoPixel/workflows/Arduino%20Library%20CI/badge.svg)](https://github.com/adafruit/Adafruit_NeoPixel/actions)[![Documentation](https://github.com/adafruit/ci-arduino/blob/master/assets/doxygen_badge.svg)](http://adafruit.github.io/Adafruit_NeoPixel/html/index.html)
 
-This is a Version that will suppprt the ESP32C2 on the SPI port.
+This is a Version that will suppprt the ESP32C2 on the SPI port.  
+But when used the **-D ADAFRUIT_SPI** Define it will use the SPI.  
 
 This also has A setMaxCurrent() so that the Current can be limmeted.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Adafruit NeoPixel Library [![Build Status](https://github.com/adafruit/Adafruit_NeoPixel/workflows/Arduino%20Library%20CI/badge.svg)](https://github.com/adafruit/Adafruit_NeoPixel/actions)[![Documentation](https://github.com/adafruit/ci-arduino/blob/master/assets/doxygen_badge.svg)](http://adafruit.github.io/Adafruit_NeoPixel/html/index.html)
 
+This is a Version that will suppprt the ESP32C2 on the SPI port.
+
+This also has A setMaxCurrent() so that the Current can be limmeted.
+
 Arduino library for controlling single-wire-based LED pixels and strip such as the [Adafruit 60 LED/meter Digital LED strip][strip], the [Adafruit FLORA RGB Smart Pixel][flora], the [Adafruit Breadboard-friendly RGB Smart Pixel][pixel], the [Adafruit NeoPixel Stick][stick], and the [Adafruit NeoPixel Shield][shield].
 
 After downloading, rename folder to 'Adafruit_NeoPixel' and install in Arduino Libraries folder. Restart Arduino IDE, then open File->Sketchbook->Library->Adafruit_NeoPixel->strandtest sketch.
@@ -78,6 +82,7 @@ Compatibility notes: Port A is not supported on any AVR processors at this time
 - delay_ns()
 - setPin()
 - setPixelColor()
+- setMaxCurrent() 
 - fill()
 - ColorHSV()
 - getPixelColor()

--- a/esp.c
+++ b/esp.c
@@ -16,10 +16,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #if defined(ESP32)
-
 #include <Arduino.h>
+#endif 
+
+#if defined(CONFIG_IDF_TARGET_ESP32C2) || defined(CONFIG_IDF_TARGET_ESP32C61)
+#ifndef ADAFRUIT_SPI
+#define ADAFRUIT_SPI  
+#endif
+#endif
+
+#if defined(ESP32) && !defined(ADAFRUIT_SPI) 
 
 #if defined(ESP_IDF_VERSION)
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
@@ -29,7 +36,6 @@
 #define HAS_ESP_IDF_5
 #endif
 #endif
-
 
 #ifdef HAS_ESP_IDF_5
 

--- a/esp.c
+++ b/esp.c
@@ -41,7 +41,7 @@
 
 static SemaphoreHandle_t show_mutex = NULL;
 
-void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
+void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz, uint32_t maxCurrent, uint32_t CurrentPerLED,boolean Dynamic) {
   // Note: Because rmtPin is shared between all instances, we will
   //  end up releasing/initializing the RMT channels each time we
   //  invoke on different pins. This is probably ok, just not
@@ -54,7 +54,24 @@ void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) 
   static rmt_data_t *led_data = NULL;
   static uint32_t led_data_size = 0;
   static int rmtPin = -1;
-
+  uint8_t MaxPower=0xff;
+  uint32_t PowerUsed=0;
+  if( CurrentPerLED != 0)
+  {
+    if(Dynamic) {
+      for (uint32_t i = 0; i < numBytes; i++) {
+      PowerUsed += (pixels[i] * CurrentPerLED) / 255;
+      } 
+      if(PowerUsed > maxCurrent) 
+        MaxPower = (maxCurrent*0xff)/PowerUsed;
+    } else 
+    {
+      if( CurrentPerLED != 0 && numBytes * CurrentPerLED > maxCurrent) 
+        MaxPower = ((maxCurrent*0xff)/numBytes)/CurrentPerLED;
+      else 
+        MaxPower = 0xff;
+    }
+  }
   if (show_mutex && xSemaphoreTake(show_mutex, SEMAPHORE_TIMEOUT_MS / portTICK_PERIOD_MS) == pdTRUE) {
     uint32_t requiredSize = numBytes * 8;
     if (requiredSize > led_data_size) {
@@ -93,9 +110,11 @@ void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) 
 
       if (rmtPin >= 0) {
         int i=0;
+        uint8_t LedPixel;
         for (int b=0; b < numBytes; b++) {
+          LedPixel = (pixels[b] * MaxPower) / 255;
           for (int bit=0; bit<8; bit++){
-            if ( pixels[b] & (1<<(7-bit)) ) {
+            if ( LedPixel & (1<<(7-bit)) ) {
               led_data[i].level0 = 1;
               led_data[i].duration0 = 8;
               led_data[i].level1 = 0;
@@ -109,7 +128,6 @@ void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) 
             i++;
           }
         }
-
         rmtWrite(pin, led_data, numBytes * 8, RMT_WAIT_FOR_EVER);
       }
     }

--- a/esp32spi.cpp
+++ b/esp32spi.cpp
@@ -1,0 +1,341 @@
+/*!
+ * @file esp32spi.cpp 
+ *
+ * @mainpage Arduino Library for driving Adafruit NeoPixel addressable LEDs,
+ * FLORA RGB Smart Pixels and compatible devicess -- WS2811, WS2812, WS2812B,
+ * SK6812, etc.
+ * This is SPI implementation for ESP32-C2/C61 as this does not have RMT peripheral
+ * But can also be used on ESP32 other variants of ESP32 that have SPI peripheral
+ * Then you will need to define ADAFRUIT_SPI before including the Adafruit_NeoPixel library
+ *
+ * @section author Author
+ *
+ * Written by Phil "Paint Your Dragon" Burgess for Adafruit Industries,
+ * with contributions by PJRC, Michael Miller and other members of the
+ * open source community. This SPI implementation was written by Emile van der Laan.
+ * 
+ * @section license License
+ *
+ * This file is part of the Adafruit_NeoPixel library.
+ *
+ * Adafruit_NeoPixel is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Adafruit_NeoPixel is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with NeoPixel. If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if defined(ESP32)
+#include <Arduino.h>
+#endif 
+
+#if defined(CONFIG_IDF_TARGET_ESP32C2) || defined(CONFIG_IDF_TARGET_ESP32C61)
+#ifndef ADAFRUIT_SPI
+#define ADAFRUIT_SPI  
+#endif
+#endif
+
+#if defined(ADAFRUIT_SPI) 
+
+//#warning "Using SPI implementation for NeoPixels on ESP32 devices"
+
+#if defined(ESP_IDF_VERSION_MAJOR)
+#if ESP_IDF_VERSION_MAJOR == 4
+#define HAS_ESP_IDF_4
+#endif
+#if ESP_IDF_VERSION_MAJOR == 5
+#define HAS_ESP_IDF_5
+#endif
+#endif
+
+#ifdef HAS_ESP_IDF_4
+#warning "Support for ESP32-C2 in ESP-IDF 4.x is not implemented"
+#endif
+#define SEMAPHORE_TIMEOUT_MS 50
+
+#ifdef HAS_ESP_IDF_5
+#include <SPI.h>
+#include "driver/spi_master.h"
+
+static SemaphoreHandle_t show_mutex = NULL;
+
+struct SpiHostUsed {
+    spi_host_device_t spi_host;
+    bool used;
+};
+
+static SpiHostUsed gSpiHostUsed[] = {
+    {SPI2_HOST, false},  // in order of preference
+#if SOC_SPI_PERIPH_NUM > 2
+    {SPI3_HOST, false},
+#endif
+#if SOC_SPI_PERIPH_NUM > 3
+    {SPI4_HOST, false},
+#endif
+#if SOC_SPI_PERIPH_NUM > 4
+    {SPI5_HOST, false},
+#endif
+    {SPI1_HOST, false},
+};
+
+/*!
+  @brief   Returns the next available SPI host device 
+  @param   None.
+  @note    Returns the next available SPI host device by scanning the gSpiHostUsed array for an unused entry, marking it as used, and returning its spi_host value; if none are available, triggers an error and returns SPI_HOST_MAX. This function is static and intended for internal use only.
+  @return  spi_host_device_t The next available SPI host device, or SPI_HOST_MAX if none are available.
+*/
+static spi_host_device_t getNextAvailableSpiHost()
+{
+    for (int i = 0; i < sizeof(gSpiHostUsed) / sizeof(gSpiHostUsed[0]); i++)
+    {
+        if (!gSpiHostUsed[i].used)
+        {
+            gSpiHostUsed[i].used = true;
+            return gSpiHostUsed[i].spi_host;
+        }
+    }
+    ESP_ERROR_CHECK(ESP_ERR_NOT_FOUND);
+    return SPI_HOST_MAX;
+}
+
+/*!
+  @brief   Releases the specified SPI host device 
+  @param   None.
+  @note    Releases the specified SPI host by marking it as unused in the gSpiHostUsed array; if the host is not found, triggers an error check with ESP_ERR_NOT_FOUND. This function is static and only accessible within the current translation unit.
+*/
+static void releaseSpiHost(spi_host_device_t spi_host)
+{
+    for (int i = 0; i < sizeof(gSpiHostUsed) / sizeof(gSpiHostUsed[0]); i++)
+    {
+        if (gSpiHostUsed[i].spi_host == spi_host)
+        {
+            gSpiHostUsed[i].used = false;
+            return;
+        }
+    }
+    ESP_ERROR_CHECK(ESP_ERR_NOT_FOUND);
+}
+
+/*!
+  @brief Encode a single LED color byte to SPI bits (WS2812)
+  @param data LED color byte (0-255)
+  @param buf Output buffer (must be zeroed, 3 bytes)
+  @return Length in bits
+  @note Each LED bit → 3 SPI bits at 2.5MHz:
+  - Low bit (0): 100 (binary) → ~400ns high, ~800ns low
+  - High bit (1): 110 (binary) → ~800ns high, ~400ns low
+  Ported directly from Espressif led_strip_spi_dev.cpp    
+*/
+static uint32_t encodeLeds800hz(uint8_t *pixels, uint32_t numBytes, uint8_t *SpiBuffer) {
+uint8_t* buf;
+    // WS2812 timing via SPI at 2.5MHz (400ns per bit):
+    // Each LED bit needs 3 SPI bits:
+    //   LED '0' → 100 (1×400ns high + 2×400ns low = 400ns + 800ns)
+    //   LED '1' → 110 (2×400ns high + 1×400ns low = 800ns + 400ns)
+    //
+    // Process byte from MSB to LSB:
+    // Byte 0bABCDEFGH → SPI bits: AAA|BBB|CCC|DDD|EEE|FFF|GGG|HHH (24 bits)
+    //
+    // Output format (3 bytes):
+    //   buf[0] = AAABBBCC (bits 7-2 of output)
+    //   buf[1] = CDDDEEEF (bits 15-10 of output)
+    //   buf[2] = FFGGGHHH (bits 23-18 of output)
+    
+    for (size_t i = 0; i < numBytes; i++) {
+      buf=&SpiBuffer[i * 3];
+    // Buffer is zero-initialized, so we only need to set high bits
+    // Process each bit from MSB (bit 7) to LSB (bit 0)
+    for (int bit = 7; bit >= 0; bit--) {
+          uint8_t pattern = (pixels[i] & (1 << bit)) ? 0b110 : 0b100;  // High bit: 110, Low bit: 100
+
+        // Map LED bit position to SPI byte/bit positions
+        int spi_bit_offset = (7 - bit) * 3;  // Each LED bit → 3 SPI bits
+        int byte_idx = spi_bit_offset / 8;
+        int bit_offset = spi_bit_offset % 8;
+
+        // Write 3-bit pattern into output buffer
+        if (bit_offset <= 5) {
+            // Pattern fits entirely in one byte
+            buf[byte_idx] |= (pattern << (5 - bit_offset));
+        } else {
+            // Pattern spans two bytes
+            buf[byte_idx] |= (pattern >> (bit_offset - 5));
+            buf[byte_idx + 1] |= (pattern << (13 - bit_offset));
+        }
+    }
+}
+    return numBytes * 3 * 8; // Each LED byte → 3 SPI bytes → 24 bits
+}
+
+/*!
+  @brief Encode a single LED color byte to SPI bits (WS2811)
+  @param data LED color byte (0-255)
+  @param buf Output buffer (must be zeroed, 3 bytes)
+  @return Length in bits
+  @note  WS2811 timing via SPI at 4.0MHz (250ns per bit):
+    Each LED bit needs 10 SPI bits.
+    LED '0' → 1100000000 (2×250ns high + 8×250ns low = 500ns + 2000ns)
+    LED '1' → 1111100000 (5×250ns high + 5×250ns low = 1250ns + 1250ns)
+*/
+uint32_t encodeLeds400hz(uint8_t *pixels, uint32_t numBytes, uint8_t *SpiBuffer) {
+    uint8_t Highbits=0;
+    uint8_t Lowbits=0;
+    uint32_t Bitpos=0;
+    for (uint32_t i = 0; i < numBytes; i++) {
+      for (uint32_t bit = 0x80; bit; bit >>= 1) {
+        if (pixels[i] & bit) {
+          Highbits =2;
+          Lowbits =8;
+        }
+        else {
+          Highbits =5;
+          Lowbits =5;
+        }
+        for(uint8_t h=0;h<Highbits;h++) {
+          SpiBuffer[Bitpos / 8] |= (1 << (7 - (Bitpos % 8)));
+          Bitpos++;
+        }
+        Bitpos+=Lowbits;       // Buffer is zero-initialized, so we only need to set high bits
+    }
+  }
+  return Bitpos;
+}
+
+/*!
+  @brief   This will release all the recourses that are used in the espShow_init() function..
+  @param   uint8_t pin 
+  @param   uint8_t *pixels
+  @param   uint32_t numBytes id the number of led * 3
+  @param   boolean is800KHz
+  @note    espShow sends pixel data to an LED strip using SPI on the specified pin, 
+           encoding each byte and managing the SPI transaction with synchronization via a semaphore. 
+           It supports both 800KHz and other timing modes, and handles errors during SPI queueing and transaction completion.
+*/
+extern "C" void espShow( uint8_t pin, uint8_t *pixels, uint32_t numBytes, bool is800KHz) {
+ spi_host_device_t mSpiHost;
+ spi_device_handle_t mSpiDevice;
+ spi_transaction_t mTransaction;   // SPI transaction descriptor
+ spi_bus_config_t bus_config = {};
+ spi_device_interface_config_t dev_config = {};
+ uint8_t *SpiBuffer=NULL;
+ int SpiBufferlen=0;  
+
+  if(numBytes>0)
+  {
+    if (show_mutex && xSemaphoreTake(show_mutex, SEMAPHORE_TIMEOUT_MS / portTICK_PERIOD_MS) == pdTRUE) {  
+        int32_t bufferzise = numBytes * 3; // size for 800KHz 
+        if(!is800KHz) bufferzise = numBytes * 10; // size for 400KHz
+        //log_e("espShow pin = %d,numBytes = %d,is800KHz = %d",pin,numBytes,is800KHz);
+        // Allocate SPI buffer (3x LED data for WS2812 encoding) (10x LED data for WS2811 encoding)   
+        SpiBuffer = (uint8_t *)malloc(bufferzise); // 3 bytes per byte
+        if(SpiBuffer == NULL) {
+            SpiBufferlen = 0;
+            log_e("espShow malloc failed ");
+            xSemaphoreGive(show_mutex);
+            return ;
+  }
+    SpiBufferlen=bufferzise;      // Each LED byte → 3 SPI bytes
+        mSpiHost = getNextAvailableSpiHost();
+        if(mSpiHost == SPI_HOST_MAX) {
+            log_e("espShow No available SPI host");
+            free(SpiBuffer);
+            SpiBuffer = NULL;
+      SpiBufferlen=0;
+            xSemaphoreGive(show_mutex);
+            return ;
+    }
+        // Initialize SPI bus
+        bus_config.mosi_io_num = pin;
+        bus_config.miso_io_num = -1;  // Not used
+        bus_config.sclk_io_num = -1;  // Not used (data-only SPI)
+        bus_config.quadwp_io_num = -1;
+        bus_config.quadhd_io_num = -1;
+        bus_config.max_transfer_sz = SpiBufferlen;
+        bus_config.data_io_default_level=0; ///< Output data IO default level when no transaction.
+        bus_config.flags = SPICOMMON_BUSFLAG_MASTER | SPICOMMON_BUSFLAG_GPIO_PINS;
+        esp_err_t ret = spi_bus_initialize(mSpiHost, &bus_config, SPI_DMA_CH_AUTO);
+        if (ret != ESP_OK) {
+            log_e("SPI bus initialize failed: \n"); //<< esp_err_to_name(ret));
+            ESP_ERROR_CHECK(ret);
+        }
+        // Configure SPI device
+        dev_config.address_bits = 0;
+        dev_config.command_bits = 0;
+        dev_config.dummy_bits=0;
+        dev_config.mode = 0;  // SPI mode 0 
+        if(is800KHz)
+        dev_config.clock_speed_hz = 2500000;  // 2.5MHz for WS2812
+        else 
+          dev_config.clock_speed_hz = 4000000;  // 4MHz for WS2811
+        dev_config.spics_io_num = -1;  // No CS pin
+        dev_config.queue_size = 1;  // Single transaction at a time
+        dev_config.flags = SPI_DEVICE_NO_DUMMY;
+        ret = spi_bus_add_device(mSpiHost, &dev_config, &mSpiDevice);
+        if (ret != ESP_OK) {
+            log_e("SPI device add failed: " );
+            spi_bus_free(mSpiHost);
+            ESP_ERROR_CHECK(ret);
+        }
+        // Prepare SPI transaction
+        memset(&mTransaction, 0, sizeof(mTransaction));
+        // Encode LED buffer to SPI buffer and return the length in bits
+        memset(SpiBuffer, 0, SpiBufferlen);     // Buffer is zero-initialized, so we only need to set high bits
+    if(is800KHz) {
+            mTransaction.length = encodeLeds800hz(pixels, numBytes, SpiBuffer);
+    } else {
+            mTransaction.length = encodeLeds400hz(pixels, numBytes, SpiBuffer);
+    }
+    mTransaction.tx_buffer = SpiBuffer;
+    mTransaction.rx_buffer = NULL;
+            ret = spi_device_acquire_bus(mSpiDevice, portMAX_DELAY);
+    if (ret != ESP_OK) {
+                log_e("SPI transaction acquire bus failed: %d", ret);// << esp_err_to_name(ret));
+        ESP_ERROR_CHECK(ret);
+    }
+            ret = spi_device_transmit(mSpiDevice, &mTransaction );
+    if (ret != ESP_OK) {
+                log_e("SPI transaction queue failed: %d", ret);// << esp_err_to_name(ret));
+        ESP_ERROR_CHECK(ret);
+    }
+            spi_device_release_bus(mSpiDevice);
+        if (mSpiDevice) {
+            spi_bus_remove_device(mSpiDevice);
+            mSpiDevice = NULL;
+            spi_bus_free(mSpiHost);
+            releaseSpiHost(mSpiHost);
+        }
+        if(SpiBuffer) {
+            free(SpiBuffer);
+            SpiBuffer = NULL;
+        }
+        SpiBufferlen = 0;
+    xSemaphoreGive(show_mutex);
+    }  else {
+        log_e("espShow could not obtain mutex");
+  }
+  } // espShow numBytes is zero"
+}
+
+/*!
+  @brief   To avoid race condition initializing the mutex.
+  @param   None.
+  @note    To avoid race condition initializing the mutex, all instances of
+           Adafruit_NeoPixel must be constructed before launching and child threads
+*/
+extern "C" void espInit() {
+  if (!show_mutex) {
+    show_mutex = xSemaphoreCreateMutex();
+  }
+}
+
+#endif // ifdef HAS_ESP_IDF_5
+#endif // if defined(ADAFRUIT_SPI)

--- a/esp32spi.cpp
+++ b/esp32spi.cpp
@@ -135,7 +135,7 @@ static void releaseSpiHost(spi_host_device_t spi_host)
   - High bit (1): 110 (binary) → ~800ns high, ~400ns low
   Ported directly from Espressif led_strip_spi_dev.cpp    
 */
-static uint32_t encodeLeds800hz(uint8_t *pixels, uint32_t numBytes, uint8_t *SpiBuffer) {
+static uint32_t encodeLeds800hz(uint8_t *pixels, uint8_t MaxPower, uint32_t numBytes, uint8_t *SpiBuffer) {
 uint8_t* buf;
     // WS2812 timing via SPI at 2.5MHz (400ns per bit):
     // Each LED bit needs 3 SPI bits:
@@ -154,8 +154,9 @@ uint8_t* buf;
       buf=&SpiBuffer[i * 3];
     // Buffer is zero-initialized, so we only need to set high bits
     // Process each bit from MSB (bit 7) to LSB (bit 0)
+    uint8_t LedPixel = (pixels[i] * MaxPower) / 255;
     for (int bit = 7; bit >= 0; bit--) {
-          uint8_t pattern = (pixels[i] & (1 << bit)) ? 0b110 : 0b100;  // High bit: 110, Low bit: 100
+          uint8_t pattern = (LedPixel & (1 << bit)) ? 0b110 : 0b100;  // High bit: 110, Low bit: 100
 
         // Map LED bit position to SPI byte/bit positions
         int spi_bit_offset = (7 - bit) * 3;  // Each LED bit → 3 SPI bits
@@ -179,20 +180,21 @@ uint8_t* buf;
 /*!
   @brief Encode a single LED color byte to SPI bits (WS2811)
   @param data LED color byte (0-255)
-  @param buf Output buffer (must be zeroed, 10 bytes / LED byte)
+  @param buf Output buffer (must be zeroed, 10 bytes / LED byte)0
   @return Length in bits
   @note  WS2811 timing via SPI at 4.0MHz (250ns per SPI bit):
     Each LED bit needs 10 SPI bits.
     LED '0' → 1100000000 (2×250ns high + 8×250ns low = 500ns + 2000ns)
     LED '1' → 1111100000 (5×250ns high + 5×250ns low = 1250ns + 1250ns)
 */
-uint32_t encodeLeds400hz(uint8_t *pixels, uint32_t numBytes, uint8_t *SpiBuffer) {
+uint32_t encodeLeds400hz(uint8_t *pixels, uint8_t MaxPower, uint32_t numBytes, uint8_t *SpiBuffer) {
     uint8_t Highbits=0;
     uint8_t Lowbits=0;
     uint32_t Bitpos=0;
     for (uint32_t i = 0; i < numBytes; i++) {
+      uint8_t LedPixel = (pixels[i] * MaxPower) / 255;
       for (uint32_t bit = 0x80; bit; bit >>= 1) {
-        if (pixels[i] & bit) {
+        if (LedPixel & bit) {
           Highbits =5;
           Lowbits =5;
         }
@@ -331,10 +333,29 @@ void espShowInit(uint8_t pin, uint32_t numBytes, bool is800KHz)
            encoding each byte and managing the SPI transaction with synchronization via a semaphore. 
            It supports both 800KHz and other timing modes, and handles errors during SPI queueing and transaction completion.
 */
-extern "C" void espShow( uint8_t pin, uint8_t *pixels, uint32_t numBytes, bool is800KHz) {
   
+
+extern "C" void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz, uint32_t maxCurrent, uint32_t CurrentPerLED,boolean Dynamic) {
+uint8_t MaxPower=0xff;
+uint32_t PowerUsed=0;  
   if(numBytes>0)
   {
+    if( CurrentPerLED != 0)
+    {
+      if(Dynamic) {
+        for (uint32_t i = 0; i < numBytes; i++) {
+        PowerUsed += (pixels[i] * CurrentPerLED) / 255;
+        } 
+        if(PowerUsed > maxCurrent) 
+          MaxPower = (maxCurrent*0xff)/PowerUsed;
+      } else 
+      {
+        if( CurrentPerLED != 0 && numBytes * CurrentPerLED > maxCurrent) 
+          MaxPower = ((maxCurrent*0xff)/numBytes)/CurrentPerLED;
+        else 
+          MaxPower = 0xff;
+      }
+    }
     espShowInit( pin,numBytes,is800KHz);         
     for(int attempt=0;attempt<1;attempt++) {
       SpiBuffer = (uint8_t *)malloc(SpiBufferlen); // 3 or 10 bytes per LED byte
@@ -349,9 +370,9 @@ extern "C" void espShow( uint8_t pin, uint8_t *pixels, uint32_t numBytes, bool i
         // Encode LED buffer to SPI buffer and return the length in bits
         memset(SpiBuffer, 0, SpiBufferlen);     // Buffer is zero-initialized, so we only need to set high bits
     if(is800KHz) {
-            mTransaction.length = encodeLeds800hz(pixels, numBytes, SpiBuffer);
+            mTransaction.length = encodeLeds800hz(pixels, MaxPower, numBytes, SpiBuffer);
     } else {
-            mTransaction.length = encodeLeds400hz(pixels, numBytes, SpiBuffer);
+            mTransaction.length = encodeLeds400hz(pixels, MaxPower, numBytes, SpiBuffer);
     }
         if (show_mutex && xSemaphoreTake(show_mutex, SEMAPHORE_TIMEOUT_MS / portTICK_PERIOD_MS) == pdTRUE) {
     mTransaction.tx_buffer = SpiBuffer;

--- a/esp8266.c
+++ b/esp8266.c
@@ -18,11 +18,11 @@ static inline uint32_t _getCycleCount(void) {
 
 #ifdef ESP8266
 IRAM_ATTR void espShow(
- uint8_t pin, uint8_t *pixels, uint32_t numBytes, __attribute__((unused)) boolean is800KHz) {
+ uint8_t pin, uint8_t *pixels, uint32_t numBytes, __attribute__((unused)) boolean is800KHz, uint32_t maxCurrent, uint32_t CurrentPerLED,boolean Dynamic) {
 #else
-void espShow(
- uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
+void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz, uint32_t maxCurrent, uint32_t CurrentPerLED,boolean Dynamic) {
 #endif
+uint8_t MaxPower=0xff;
 
 #define CYCLES_800_T0H  (F_CPU / 2500001) // 0.4us
 #define CYCLES_800_T1H  (F_CPU / 1250001) // 0.8us
@@ -38,10 +38,24 @@ void espShow(
   uint32_t pinMask;
   pinMask   = _BV(pin);
 #endif
+uint32_t PowerUsed = 0;
+ if(Dynamic) {
+    for (uint32_t i = 0; i < numBytes; i++) {
+    PowerUsed += (pixels[i] * CurrentPerLED) / 255;
+    } 
+    if(PowerUsed > maxCurrent) 
+      MaxPower = (maxCurrent*0xff)/PowerUsed;
+  } else 
+  {
+    if( CurrentPerLED != 0 && numBytes * CurrentPerLED > maxCurrent) 
+      MaxPower = ((maxCurrent*0xff)/numBytes)/CurrentPerLED;
+    else 
+      MaxPower = 0xff;
+  }
 
   p         =  pixels;
   end       =  p + numBytes;
-  pix       = *p++;
+  pix       = (*p++) * MaxPower / 255;
   mask      = 0x80;
   startTime = 0;
 
@@ -76,7 +90,7 @@ void espShow(
 #endif
     if(!(mask >>= 1)) {                                   // Next bit/byte
       if(p >= end) break;
-      pix  = *p++;
+      pix  = (*p++) * MaxPower / 255;
       mask = 0x80;
     }
   }

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
 name=Adafruit NeoPixel
-version=1.15.2
+version=1.15.2B
 author=Adafruit
-maintainer=Adafruit <info@adafruit.com>
+maintainer=Adafruit <adafruit@emsign.nl>
 sentence=Arduino library for controlling single-wire-based LED pixels and strip.
 paragraph=Arduino library for controlling single-wire-based LED pixels and strip.
 category=Display
-url=https://github.com/adafruit/Adafruit_NeoPixel
+url=https://github.com/EmileSpecialProducts/Adafruit_NeoPixel
 architectures=*
 includes=Adafruit_NeoPixel.h


### PR DESCRIPTION
Added support for the SPI interface for the ESP32-C2 but can also be used for the other devices.

The code is standard only for the ESP32-C2 / C61 (When this will be supported by Arduino platform)
But can also be enabled for the other devices when the #define ADAFRUIT_SPI is added.
This is tested on the ESP32-C3/S3/C2.
On one channel and two channels.
This will resolve the issue https://github.com/adafruit/Adafruit_NeoPixel/issues/450
