### PR TITLE
Add Support for XMC1400 2GO (KIT_XMC14_2GO)

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -2502,7 +2502,7 @@ void Adafruit_NeoPixel::show(void) {
 #endif
 
 //----
-#elif defined(XMC1100_XMC2GO) || defined(XMC1400_Arduino_Kit) || defined(XMC1100_H_BRIDGE2GO) || defined(XMC1100_Boot_Kit)  || defined(XMC1300_Boot_Kit)
+#elif defined(XMC1100_XMC2GO) || defined(XMC1400_XMC2GO) || defined(XMC1400_Arduino_Kit) || defined(XMC1100_H_BRIDGE2GO) || defined(XMC1100_Boot_Kit)  || defined(XMC1300_Boot_Kit)
 
   // XMC1100/1200/1300 with ARM Cortex M0 are running with 32MHz, XMC1400 runs with 48MHz so may not work
   // Tried this with a timer/counter, couldn't quite get adequate
@@ -3775,3 +3775,4 @@ neoPixelType Adafruit_NeoPixel::str2order(const char *v) {
   if (w < 0) w = r; // If 'w' not specified, duplicate r bits
   return (w << 6) | (r << 4) | ((g & 3) << 2) | (b & 3);
 }
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Arduino library for controlling single-wire-based LED pixels and strip such as the [Adafruit 60 LED/meter Digital LED strip][strip], the [Adafruit FLORA RGB Smart Pixel][flora], the [Adafruit Breadboard-friendly RGB Smart Pixel][pixel], the [Adafruit NeoPixel Stick][stick], and the [Adafruit NeoPixel Shield][shield].
 
-After downloading, rename folder to 'Adafruit_NeoPixel' and install in Arduino Libraries folder. Restart Arduino IDE, then open *File* → *Sketchbook* → *Library* → *Adafruit_NeoPixel* → *strandtest* sketch.
+After downloading, rename folder to 'Adafruit_NeoPixel' and install in Arduino Libraries folder. Restart Arduino IDE, then open File->Sketchbook->Library->Adafruit_NeoPixel->strandtest sketch.
 
 Compatibility notes: Port A is not supported on any AVR processors at this time
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Arduino library for controlling single-wire-based LED pixels and strip such as the [Adafruit 60 LED/meter Digital LED strip][strip], the [Adafruit FLORA RGB Smart Pixel][flora], the [Adafruit Breadboard-friendly RGB Smart Pixel][pixel], the [Adafruit NeoPixel Stick][stick], and the [Adafruit NeoPixel Shield][shield].
 
-After downloading, rename folder to 'Adafruit_NeoPixel' and install in Arduino Libraries folder. Restart Arduino IDE, then open File->Sketchbook->Library->Adafruit_NeoPixel->strandtest sketch.
+After downloading, rename folder to 'Adafruit_NeoPixel' and install in Arduino Libraries folder. Restart Arduino IDE, then open *File* → *Sketchbook* → *Library* → *Adafruit_NeoPixel* → *strandtest* sketch.
 
 Compatibility notes: Port A is not supported on any AVR processors at this time
 
@@ -60,6 +60,7 @@ Compatibility notes: Port A is not supported on any AVR processors at this time
   - Infineon XMC1100 BootKit @ 32 MHz
   - Infineon XMC1100 2Go @ 32 MHz
   - Infineon XMC1300 BootKit  @ 32 MHz
+  - Infineon XMC1400 2Go @ 48 MHz
   - Infineon XMC4700 RelaxKit, XMC4800 RelaxKit, XMC4800 IoT Amazon FreeRTOS Kit @ 144 MHz
   - Sipeed Maix Bit (K210 processor)
 


### PR DESCRIPTION
# Summary

* This PR adds support for the Infineon XMC1400 2GO evaluation board (KIT_XMC14_2GO) to the Adafruit_NeoPixel library.
* The change consists of recognizing the XMC1400_XMC2GO board in `Adafruit_NeoPixel.cpp` (around line 2505) so that NeoPixel functionality works on this platform.

## Motivation and Context
* The XMC1400 2GO was not previously supported by Adafruit_NeoPixel, preventing users of this board from using the library.
* Infineon Technologies AG (CSS DSI TM AE) implemented and verified the necessary changes to enable compatibility.

## Changes
* Added a preprocessor check for XMC1400_XMC2GO in `Adafruit_NeoPixel.cpp` to route to the correct implementation for this board.
* No functional changes for other platforms; this is an additive board support update.

## Testing
* Verified with multiple notebooks and several XMC1400 2Go boards.
* Standard NeoPixel examples (e.g., strandtest) run successfully on the XMC1400 2GO.

## Links
* Board: https://www.infineon.com/evaluation-board/KIT_XMC14-2GO
* Library: https://github.com/adafruit/Adafruit_NeoPixel


Thank you for reviewing this contribution from Infineon Technologies AG (CSS DSI TM AE).
