### PR TITLE
Support timing for CH32V00x running at 48MHz

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -272,11 +272,13 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
       // High 800ns
       *set = ch_pin;
       __asm volatile ("nop; nop; nop; nop; nop; nop; nop; nop;"
-//        "nop; nop; nop; nop; nop; nop; nop; nop;"
-//        "nop; nop; nop; nop; nop; nop; nop; nop;"
-//        "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop;"
+#if CH32_F_CPU >= 56000000
+        "nop; nop; nop; nop; nop; nop; nop; nop;"
+        "nop; nop; nop; nop; nop; nop; nop; nop;"
+        "nop; nop; nop; nop; nop; nop; nop; nop;"
+#endif
 #if CH32_F_CPU >= 72000000
         "nop; nop; nop; nop; nop; nop; nop;"
         "nop; nop; nop; nop; nop; nop;"
@@ -300,8 +302,10 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
       // Low 450ns
       *clr = ch_pin;
       __asm volatile ("nop; nop; nop; nop; nop; nop; nop; nop;"
-//        "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop;"
+#if CH32_F_CPU >= 56000000
+        "nop; nop; nop; nop; nop; nop; nop; nop;"
+#endif
 #if CH32_F_CPU >= 72000000
         "nop; nop; nop; nop; nop; nop; nop; nop; nop;"
 #endif
@@ -320,8 +324,10 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
       // High 400ns
       *set = ch_pin;
       __asm volatile ("nop; nop; nop; nop; nop; nop; nop; nop;"
-//        "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop;"
+#if CH32_F_CPU >= 56000000
+        "nop; nop; nop; nop; nop; nop; nop; nop;"
+#endif
 #if CH32_F_CPU >= 72000000
         "nop; nop; nop; nop; nop; nop; nop;"
 #endif
@@ -340,10 +346,12 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
       // Low 850ns
       *clr = ch_pin;
       __asm volatile ("nop; nop; nop; nop; nop; nop; nop; nop;"
-//        "nop; nop; nop; nop; nop; nop; nop; nop;"
-//        "nop; nop; nop; nop; nop; nop; nop; nop;"
-//        "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop; nop; nop; nop; nop;"
+#if CH32_F_CPU >= 56000000
+        "nop; nop; nop; nop; nop; nop; nop; nop;"
+        "nop; nop; nop; nop; nop; nop; nop; nop;"
+        "nop; nop; nop; nop; nop; nop; nop; nop;"
+#endif
 #if CH32_F_CPU >= 72000000
         "nop; nop; nop;"
         "nop; nop; nop; nop; nop; nop; nop; nop;"

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -22,6 +22,7 @@
  * Written by Phil "Paint Your Dragon" Burgess for Adafruit Industries,
  * with contributions by PJRC, Michael Miller and other members of the
  * open source community.
+ * Minor change in timing 20260126 by Maxint-RD
  *
  * @section license License
  *

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -22,7 +22,7 @@
  * Written by Phil "Paint Your Dragon" Burgess for Adafruit Industries,
  * with contributions by PJRC, Michael Miller and other members of the
  * open source community.
- * Minor change in timing 20260126 by Maxint-RD
+ * Minor change in timing for CH32 @48MHz by Maxint-RD 20260126.
  *
  * @section license License
  *
@@ -274,9 +274,9 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
       *set = ch_pin;
       __asm volatile ("nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop; nop; nop; nop; nop; nop; nop; nop;"
-        "nop;"
+        "nop; nop; nop; nop; nop; nop; nop;"
 #if CH32_F_CPU >= 56000000
-        "nop; nop; nop; nop; nop; nop; nop; nop;"
+        "nop; nop;"
         "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop; nop; nop; nop; nop; nop; nop; nop;"
 #endif
@@ -302,9 +302,9 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
 
       // Low 450ns
       *clr = ch_pin;
-      __asm volatile ("nop; nop; nop; nop; nop; nop; nop; nop;"
-        "nop;"
+      __asm volatile ("nop; nop;"
 #if CH32_F_CPU >= 56000000
+        "nop; nop; nop; nop; nop; nop; nop;"
         "nop; nop; nop; nop; nop; nop; nop; nop;"
 #endif
 #if CH32_F_CPU >= 72000000
@@ -325,9 +325,8 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
       // High 400ns
       *set = ch_pin;
       __asm volatile ("nop; nop; nop; nop; nop; nop; nop; nop;"
-        "nop;"
 #if CH32_F_CPU >= 56000000
-        "nop; nop; nop; nop; nop; nop; nop; nop;"
+        "nop; nop; nop; nop; nop; nop; nop; nop; nop;"
 #endif
 #if CH32_F_CPU >= 72000000
         "nop; nop; nop; nop; nop; nop; nop;"
@@ -347,8 +346,9 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
       // Low 850ns
       *clr = ch_pin;
       __asm volatile ("nop; nop; nop; nop; nop; nop; nop; nop;"
-        "nop; nop; nop; nop; nop;"
+        "nop; nop; nop; nop;"
 #if CH32_F_CPU >= 56000000
+        "nop;"
         "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop; nop; nop; nop; nop; nop; nop; nop;"

--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -272,9 +272,9 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
       // High 800ns
       *set = ch_pin;
       __asm volatile ("nop; nop; nop; nop; nop; nop; nop; nop;"
-        "nop; nop; nop; nop; nop; nop; nop; nop;"
-        "nop; nop; nop; nop; nop; nop; nop; nop;"
-        "nop; nop; nop; nop; nop; nop; nop; nop;"
+//        "nop; nop; nop; nop; nop; nop; nop; nop;"
+//        "nop; nop; nop; nop; nop; nop; nop; nop;"
+//        "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop;"
 #if CH32_F_CPU >= 72000000
@@ -300,7 +300,7 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
       // Low 450ns
       *clr = ch_pin;
       __asm volatile ("nop; nop; nop; nop; nop; nop; nop; nop;"
-        "nop; nop; nop; nop; nop; nop; nop; nop;"
+//        "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop;"
 #if CH32_F_CPU >= 72000000
         "nop; nop; nop; nop; nop; nop; nop; nop; nop;"
@@ -320,7 +320,7 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
       // High 400ns
       *set = ch_pin;
       __asm volatile ("nop; nop; nop; nop; nop; nop; nop; nop;"
-        "nop; nop; nop; nop; nop; nop; nop; nop;"
+//        "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop;"
 #if CH32_F_CPU >= 72000000
         "nop; nop; nop; nop; nop; nop; nop;"
@@ -340,9 +340,9 @@ static void ch32Show(GPIO_TypeDef* ch_port, uint32_t ch_pin, uint8_t* pixels, ui
       // Low 850ns
       *clr = ch_pin;
       __asm volatile ("nop; nop; nop; nop; nop; nop; nop; nop;"
-        "nop; nop; nop; nop; nop; nop; nop; nop;"
-        "nop; nop; nop; nop; nop; nop; nop; nop;"
-        "nop; nop; nop; nop; nop; nop; nop; nop;"
+//        "nop; nop; nop; nop; nop; nop; nop; nop;"
+//        "nop; nop; nop; nop; nop; nop; nop; nop;"
+//        "nop; nop; nop; nop; nop; nop; nop; nop;"
         "nop; nop; nop; nop; nop;"
 #if CH32_F_CPU >= 72000000
         "nop; nop; nop;"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Compatibility notes: Port A is not supported on any AVR processors at this time
   - Adafruit STM32 Feather @ 120 MHz
   - ESP8266 any speed
   - ESP32 any speed
+  - WCH CH32 @ 48 MHz and higher speeds
   - Nordic nRF52 (Adafruit Feather nRF52), nRF51 (micro:bit)
   - Infineon XMC1100 BootKit @ 32 MHz
   - Infineon XMC1100 2Go @ 32 MHz


### PR DESCRIPTION
The library already has support for the CH32 family of microprocessors (thanks @hathach) , but it didn't work for the lower clock speed of 48 MHz that is used by the popular CH32V003 and its newer CH32V00x siblings.

As mentioned in [this commit](https://github.com/adafruit/Adafruit_NeoPixel/commit/9dd0fcfb4022c63fe370099ee42127471eda7e09) the CH32 family was already supported for frequencies of 56 MHz and higher. This PR decreases the number of "nop;" codes used in `ch32Show()` within [Adafruit_NeoPixel.cpp](https://github.com/adafruit/Adafruit_NeoPixel/blob/master/Adafruit_NeoPixel.cpp), to specifically support 48 MHz. For higher frequencies the total number of nops remains the same.

The modified code was tested to work fine using the examples "strandtest" and "simple",  with both short (8) and long (256) strings of Neopixels. Testing was done
on these CH32 processors, all running at 48MHz:
- CH32V002J4M6 (SOP8) / CH32V002D4U6 (QFN12)
- CH32V003J4M6 (SOP8)
- CH32V003A4M6 (SOP16)
- CH32V006F8P6 (TSSOP20)
- CH32V006E8R6 (QSOP24) 
- CH32V006K8U6 (QFN32)


More precise testing and measurement of timing was done use the CH32V006E8R6 with different compilation options. Timing was measured with a cheap 24MHz logical analyzer. I didn't see significant differences for either -Os, -Os with LTO or -Og (for debugging with symbols). Bit-timing was fairly close to the 1250ns specified for 800kHz Neopixels, with average byte-timing only a little over 10us.

Thanks @BitByteBeetle for his contribution to test this PR with all these processors.