### PR TITLE
RP2040 interrupts do not need to be disabled as library uses PIO

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -455,7 +455,8 @@ void Adafruit_NeoPixel::show(void) {
 
   // NRF52 may use PWM + DMA (if available), may not need to disable interrupt
   // ESP32 may not disable interrupts because espShow() uses RMT which tries to acquire locks
-#if !(defined(NRF52) || defined(NRF52_SERIES) || defined(ESP32))
+  // RP2040 uses PIO so interrupts can continue.
+#if ( (!(defined(NRF52)) && !(defined(ARDUINO_ARCH_RP2040))) || defined(NRF52_SERIES) || defined(ESP32))
   noInterrupts(); // Need 100% focus on instruction timing
 #endif
 


### PR DESCRIPTION
The interrupts do not need to be disabled during show() for the RP2040 as hardware PIO generates the timing signals.

Tested on Arduino Nano RP2040 Connect board with Arduino-pico board package.

Solves:
https://github.com/adafruit/Adafruit_NeoPixel/issues/441
