### PR TITLE
boards: support Zephyr-based STM32 boards

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -2872,7 +2872,7 @@ if(is800KHz) {
     // ToDo!
   }
 #endif
-#elif defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_ARDUINO_CORE_STM32) || defined(_PY32_DEF_)
+#elif defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_ARDUINO_CORE_STM32) || defined(_PY32_DEF_) || defined(CONFIG_SOC_FAMILY_STM32)
   uint8_t *p = pixels, *end = p + numBytes, pix = *p++, mask = 0x80;
   uint32_t cyc;
   uint32_t saveLoad = SysTick->LOAD, saveVal = SysTick->VAL;
@@ -3356,7 +3356,7 @@ void Adafruit_NeoPixel::setPin(int16_t p) {
   port = portOutputRegister(digitalPinToPort(p));
   pinMask = digitalPinToBitMask(p);
 #endif
-#if defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_ARDUINO_CORE_STM32)
+#if defined(ARDUINO_ARCH_STM32) || defined(ARDUINO_ARCH_ARDUINO_CORE_STM32) || defined(CONFIG_SOC_FAMILY_STM32)
   gpioPort = digitalPinToPort(p);
   gpioPin = STM_LL_GPIO_PIN(digitalPinToPinName(p));
 #elif defined(_PY32_DEF_)

--- a/Adafruit_NeoPixel.h
+++ b/Adafruit_NeoPixel.h
@@ -412,7 +412,8 @@ protected:
 #if defined(ARDUINO_ARCH_STM32) || \
     defined(ARDUINO_ARCH_ARDUINO_CORE_STM32) || \
     defined(ARDUINO_ARCH_CH32) || \
-    defined(_PY32_DEF_)
+    defined(_PY32_DEF_) || \
+    defined(CONFIG_SOC_FAMILY_STM32)
   GPIO_TypeDef *gpioPort; ///< Output GPIO PORT
   uint32_t gpioPin;       ///< Output GPIO PIN
 #endif


### PR DESCRIPTION
This PR enables the most beautiful LEDs to shine on boards supported by Zephyr Arduino core :slightly_smiling_face: 
The chosen define doesn't clash with mbed support for Giga.

Requires https://github.com/arduino/ArduinoCore-zephyr/pull/434 

Thanks!