### PR TITLE
fix: match espShow's pin parameter type across translation units

### DIFF
--- a/esp.c
+++ b/esp.c
@@ -35,7 +35,7 @@
 
 static SemaphoreHandle_t show_mutex = NULL;
 
-void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
+void espShow(uint16_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
   // Note: Because rmtPin is shared between all instances, we will
   //  end up releasing/initializing the RMT channels each time we
   //  invoke on different pins. This is probably ok, just not
@@ -185,7 +185,7 @@ static void IRAM_ATTR ws2812_rmt_adapter(const void *src, rmt_item32_t *dest, si
     *item_num = num;
 }
 
-void espShow(uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
+void espShow(uint16_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
     // Reserve channel
     rmt_channel_t channel = ADAFRUIT_RMT_CHANNEL_MAX;
     for (size_t i = 0; i < ADAFRUIT_RMT_CHANNEL_MAX; i++) {

--- a/esp8266.c
+++ b/esp8266.c
@@ -18,10 +18,10 @@ static inline uint32_t _getCycleCount(void) {
 
 #ifdef ESP8266
 IRAM_ATTR void espShow(
- uint8_t pin, uint8_t *pixels, uint32_t numBytes, __attribute__((unused)) boolean is800KHz) {
+ uint16_t pin, uint8_t *pixels, uint32_t numBytes, __attribute__((unused)) boolean is800KHz) {
 #else
 void espShow(
- uint8_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
+ uint16_t pin, uint8_t *pixels, uint32_t numBytes, boolean is800KHz) {
 #endif
 
 #define CYCLES_800_T0H  (F_CPU / 2500001) // 0.4us


### PR DESCRIPTION
Fixes #400.

### Problem

`Adafruit_NeoPixel.cpp` declares (and calls) the ESP8266/ESP32 `espShow()` helper with a `uint16_t pin` parameter, matching the class's own `int16_t pin` member:

```cpp
extern "C" void espShow(uint16_t pin, uint8_t *pixels, uint32_t numBytes, uint8_t type);
```

but `esp.c` and `esp8266.c` both define it with `uint8_t pin` instead - a real cross-translation-unit type mismatch (a One Definition Rule violation for an `extern "C"` function, since C doesn't have C++ name mangling to catch this at link time). Building with `-flto` correctly flags this (as reported in the issue):

```
warning: type of 'espShow' does not match original declaration [-Wlto-type-mismatch]
note: type 'uint8_t' should match type 'uint16_t'
```

Most builds don't use LTO so this goes unnoticed in practice, but it's still undefined behavior per the standard, and nothing guarantees the mismatch stays harmless across compilers/optimization levels/calling conventions.

### Fix

Changed `esp.c`'s two `espShow()` definitions and `esp8266.c`'s two (`ESP8266`/non-`ESP8266`) definitions to use `uint16_t pin`, matching the declaration in `Adafruit_NeoPixel.cpp`.

### Test plan

No ESP32/ESP8266 hardware+toolchain handy, so I reproduced the exact diagnostic the issue reporter used with a standalone host-side repro: two translation units with the same declaration/definition mismatch as before the fix, compiled with `gcc -flto -Wlto-type-mismatch`, produce the identical warning (`type 'uint8_t' should match type 'uint16_t'`); after applying the same fix (both sides `uint16_t`), the warning disappears.

### Disclosure

Generative AI (Claude) was used to help investigate this issue, implement, and verify this fix. All changes were reviewed by me before submission.
